### PR TITLE
Secure SQL queries with prepared statements

### DIFF
--- a/process/operations/main.php
+++ b/process/operations/main.php
@@ -6,7 +6,7 @@
     $sql = "DELETE FROM `tmp2` WHERE `time` < DATE_SUB(NOW(),INTERVAL '00:10' MINUTE_SECOND)";
     $result = mysqli_query($conn, $sql) or die("Invalid query: 1" . mysqli_error());
     if (isset($_GET['id'])) {
-        $usn = strtoupper($_GET['id']);
+        $usn = strtoupper(sanitize($conn, $_GET['id']));
         $date = date('Y-m-d');
         $time = date('H:i:s');
         error_reporting(E_ALL);
@@ -18,17 +18,26 @@
         $data1 = mysqli_fetch_row($result);
         $stmt->close();
         //image fetching
-        $sql = "SELECT imagefile FROM patronimage WHERE borrowernumber = '$data1[1]'";
-        $result = mysqli_query($koha, $sql);
+        $stmt = $koha->prepare('SELECT imagefile FROM patronimage WHERE borrowernumber = ?');
+        $stmt->bind_param('i', $data1[1]);
+        $stmt->execute();
+        $result = $stmt->get_result();
         $data2 = mysqli_fetch_row($result);
+        $stmt->close();
         //Patron category code fetching
-        $sql = "SELECT description FROM categories WHERE categorycode = '$data1[3]'";
-        $result = mysqli_query($koha, $sql);
+        $stmt = $koha->prepare('SELECT description FROM categories WHERE categorycode = ?');
+        $stmt->bind_param('s', $data1[3]);
+        $stmt->execute();
+        $result = $stmt->get_result();
         $data3 = mysqli_fetch_row($result);
+        $stmt->close();
         //Branch information fetching
-        $sql = "SELECT branchname FROM branches WHERE branchcode = '$data1[4]'";
-        $result = mysqli_query($koha, $sql);
+        $stmt = $koha->prepare('SELECT branchname FROM branches WHERE branchcode = ?');
+        $stmt->bind_param('s', $data1[4]);
+        $stmt->execute();
+        $result = $stmt->get_result();
         $data4 = mysqli_fetch_row($result);
+        $stmt->close();
         if ($data1) {
             $_SESSION['categorycode'] = $data1[3];
             $_SESSION['dateofbirth'] = $data1[9];

--- a/process/operations/stats.php
+++ b/process/operations/stats.php
@@ -1,19 +1,39 @@
 <?php
-  $loc = $_SESSION['loc'];
+  $loc = sanitize($conn, $_SESSION['loc']);
   $date = date('Y-m-d');
-  $query = "SELECT count(sl) FROM `inout` WHERE date='$date' and loc='$loc'";
-  $result = mysqli_query($conn, $query) or die("Invalid query: " . mysqli_error($conn));
+
+  $stmt = $conn->prepare('SELECT count(sl) FROM `inout` WHERE date=? and loc=?');
+  $stmt->bind_param('ss', $date, $loc);
+  $stmt->execute();
+  $result = $stmt->get_result();
   $visit = mysqli_fetch_row($result);
-  $query = "SELECT count(sl) FROM `inout` WHERE date='$date' and gender='M' and status='IN' and loc='$loc'";
-  $result = mysqli_query($conn, $query) or die("Invalid query: " . mysqli_error($conn));
+  $stmt->close();
+
+  $stmt = $conn->prepare("SELECT count(sl) FROM `inout` WHERE date=? and gender='M' and status='IN' and loc=?");
+  $stmt->bind_param('ss', $date, $loc);
+  $stmt->execute();
+  $result = $stmt->get_result();
   $male = mysqli_fetch_row($result);
-  $query = "SELECT count(sl) FROM `inout` WHERE date='$date' and gender='F' and status='IN' and loc='$loc'";
-  $result = mysqli_query($conn, $query) or die("Invalid query: " . mysqli_error($conn));
+  $stmt->close();
+
+  $stmt = $conn->prepare("SELECT count(sl) FROM `inout` WHERE date=? and gender='F' and status='IN' and loc=?");
+  $stmt->bind_param('ss', $date, $loc);
+  $stmt->execute();
+  $result = $stmt->get_result();
   $female = mysqli_fetch_row($result);
-  $query = "SELECT count(sl) FROM `inout` WHERE date='$date' and status='IN' and loc='$loc'";
-  $result = mysqli_query($conn, $query) or die("Invalid query: " . mysqli_error($conn));
+  $stmt->close();
+
+  $stmt = $conn->prepare("SELECT count(sl) FROM `inout` WHERE date=? and status='IN' and loc=?");
+  $stmt->bind_param('ss', $date, $loc);
+  $stmt->execute();
+  $result = $stmt->get_result();
   $tin = mysqli_fetch_row($result);
+  $stmt->close();
+
   // $query = "SELECT cc, COUNT(sl) FROM `inout` GROUP BY cc LIMIT 4";
-  $query = "SELECT cc, COUNT(sl) FROM `inout` WHERE date='$date' AND loc='$loc' GROUP BY cc ORDER BY RAND() LIMIT 3 ";
-  $extraCount = mysqli_query($conn, $query) or die("Invalid query: " . mysqli_error($conn));
+  $stmt = $conn->prepare("SELECT cc, COUNT(sl) FROM `inout` WHERE date=? AND loc=? GROUP BY cc ORDER BY RAND() LIMIT 3 ");
+  $stmt->bind_param('ss', $date, $loc);
+  $stmt->execute();
+  $extraCount = $stmt->get_result();
+  $stmt->close();
 ?>


### PR DESCRIPTION
## Summary
- sanitize id parameter in main operation
- use prepared statements to fetch patron image, category and branch
- rewrite stats.php using prepared statements
- refactor process.php operations to bind parameters

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68559792f9d88326a35dacbe64060664