### PR TITLE
Update TTS env defaults and class

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,6 @@ KOHA_DB_PASS=your_koha_pass
 KOHA_DB_NAME=koha_db
 
 # Google Cloud Text-to-Speech
-TTS_CREDENTIALS_PATH=/path/to/credentials.json
+TTS_CREDENTIALS_PATH=/u01/vhosts/inout.upeu.edu.pe/credentials/inout-tts.json
 TTS_LANGUAGE_CODE=es-ES
-#TTS_VOICE=
+TTS_VOICE=es-ES-Standard-A

--- a/README.md
+++ b/README.md
@@ -62,8 +62,13 @@ Sigue estos pasos para configurar el proyecto en tu entorno local:
     -   El sistema te redirigirá a la página de inicio de sesión (`login.php`).
 5.  **Configurar Google Cloud Text-to-Speech:**
     -   Crea un proyecto en Google Cloud y genera una clave de servicio (archivo JSON).
-    -   Define la ruta del JSON en `TTS_CREDENTIALS_PATH` dentro de tu `.env`.
-    -   Establece `TTS_LANGUAGE_CODE` y opcionalmente `TTS_VOICE` con el idioma y voz preferidos.
+    -   Define las variables `TTS_CREDENTIALS_PATH`, `TTS_LANGUAGE_CODE` y `TTS_VOICE` en tu archivo `.env`:
+
+        ```env
+        TTS_CREDENTIALS_PATH=/u01/vhosts/inout.upeu.edu.pe/credentials/inout-tts.json
+        TTS_LANGUAGE_CODE=es-ES
+        TTS_VOICE=es-ES-Standard-A
+        ```
 
 ## ⚙️ Uso
 

--- a/functions/PersonalizedGreeting.php
+++ b/functions/PersonalizedGreeting.php
@@ -3,6 +3,7 @@ class PersonalizedGreeting
 {
     private $languageCode;
     private $credentialsPath;
+    private $voiceName;
 
     public function __construct()
     {
@@ -10,6 +11,7 @@ class PersonalizedGreeting
         $env = file_exists($envPath) ? parse_ini_file($envPath, false, INI_SCANNER_TYPED) : [];
         $this->credentialsPath = $env['TTS_CREDENTIALS_PATH'] ?? '';
         $this->languageCode = $env['TTS_LANGUAGE_CODE'] ?? 'es-ES';
+        $this->voiceName = $env['TTS_VOICE'] ?? null;
     }
 
     public function buildGreeting(string $name, string $timeOfDay, string $category, ?string $birthday = null, ?string $country = null): string
@@ -64,6 +66,9 @@ class PersonalizedGreeting
 
         $voice = (new Google\Cloud\TextToSpeech\V1\VoiceSelectionParams())
             ->setLanguageCode($this->languageCode);
+        if ($this->voiceName) {
+            $voice->setName($this->voiceName);
+        }
 
         $audioConfig = (new Google\Cloud\TextToSpeech\V1\AudioConfig())
             ->setAudioEncoding(Google\Cloud\TextToSpeech\V1\AudioEncoding::MP3);


### PR DESCRIPTION
## Summary
- document Google TTS variables in README
- set example credentials path and voice in `.env.example`
- allow optional voice name in `PersonalizedGreeting`

## Testing
- `php -l functions/PersonalizedGreeting.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6855801da75c8326927354c2c290be53