### PR TITLE
Add TTS test script and update usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ Una vez instalado y configurado, puedes:
 -   **Gestionar Usuarios:** Accede a la sección de administración para agregar, modificar o eliminar usuarios y sus roles.
 -   **Registrar Entradas/Salidas:** Utiliza las interfaces designadas para registrar los movimientos.
 -   **Generar Reportes:** Consulta los reportes para obtener información detallada sobre los datos.
+-   **Probar Google TTS:** Con las credenciales configuradas en el archivo `.env`, ejecuta:
+    ```bash
+    php tests/tts_test.php
+    ```
+    Esto generará el archivo `tests/tts_test.mp3` como prueba de que la integración funciona.
 
 ## 📂 Estructura del Proyecto
 

--- a/tests/tts_test.php
+++ b/tests/tts_test.php
@@ -1,0 +1,42 @@
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+use Google\Cloud\TextToSpeech\V1\TextToSpeechClient;
+use Google\Cloud\TextToSpeech\V1\SynthesisInput;
+use Google\Cloud\TextToSpeech\V1\VoiceSelectionParams;
+use Google\Cloud\TextToSpeech\V1\AudioConfig;
+use Google\Cloud\TextToSpeech\V1\AudioEncoding;
+
+$envPath = __DIR__ . '/../.env';
+$env = file_exists($envPath) ? parse_ini_file($envPath, false, INI_SCANNER_TYPED) : [];
+$credentials = $env['TTS_CREDENTIALS_PATH'] ?? null;
+$languageCode = $env['TTS_LANGUAGE_CODE'] ?? 'es-ES';
+$voiceName = $env['TTS_VOICE'] ?? null;
+
+if (!$credentials) {
+    fwrite(STDERR, "Google credentials are not configured.\n");
+    exit(1);
+}
+
+$client = new TextToSpeechClient([
+    'credentials' => $credentials,
+]);
+
+$input = (new SynthesisInput())
+    ->setText('Esta es una prueba de TTS.');
+
+$voice = (new VoiceSelectionParams())
+    ->setLanguageCode($languageCode);
+if ($voiceName) {
+    $voice->setName($voiceName);
+}
+
+$audioConfig = (new AudioConfig())
+    ->setAudioEncoding(AudioEncoding::MP3);
+
+$response = $client->synthesizeSpeech($input, $voice, $audioConfig);
+$client->close();
+
+file_put_contents(__DIR__ . '/tts_test.mp3', $response->getAudioContent());
+
+echo "Created tts_test.mp3\n";
+


### PR DESCRIPTION
## Summary
- add a script `tests/tts_test.php` to verify Google Text-to-Speech configuration
- document how to run the test and mention the resulting `tts_test.mp3`

## Testing
- `php -l tests/tts_test.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6858406ac85483269140d5d6858ef97b