### PR TITLE
Add TTS test script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Sigue estos pasos para configurar el proyecto en tu entorno local:
         TTS_LANGUAGE_CODE=es-ES
         TTS_VOICE=es-ES-Standard-A
         ```
+-   Para verificar tu configuración de TTS, ejecuta `php tests/tts_test.php`. Este script guarda `tests/tts_test.mp3`.
+
 
 ## ⚙️ Uso
 

--- a/tests/tts_test.php
+++ b/tests/tts_test.php
@@ -1,0 +1,38 @@
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+
+$envPath = dirname(__DIR__) . '/.env';
+$env = file_exists($envPath) ? parse_ini_file($envPath, false, INI_SCANNER_TYPED) : [];
+
+$credentials = $env['TTS_CREDENTIALS_PATH'] ?? null;
+if ($credentials) {
+    putenv('GOOGLE_APPLICATION_CREDENTIALS=' . $credentials);
+}
+
+use Google\Cloud\TextToSpeech\V1\Client\TextToSpeechClient;
+use Google\Cloud\TextToSpeech\V1\SynthesisInput;
+use Google\Cloud\TextToSpeech\V1\VoiceSelectionParams;
+use Google\Cloud\TextToSpeech\V1\AudioConfig;
+use Google\Cloud\TextToSpeech\V1\AudioEncoding;
+
+$text = 'Prueba de síntesis de voz';
+$languageCode = $env['TTS_LANGUAGE_CODE'] ?? 'es-ES';
+$voiceName = $env['TTS_VOICE'] ?? null;
+
+$client = new TextToSpeechClient();
+
+$input = (new SynthesisInput())->setText($text);
+$voice = (new VoiceSelectionParams())
+    ->setLanguageCode($languageCode);
+if ($voiceName) {
+    $voice->setName($voiceName);
+}
+$audioConfig = (new AudioConfig())
+    ->setAudioEncoding(AudioEncoding::MP3);
+
+$response = $client->synthesizeSpeech($input, $voice, $audioConfig);
+$client->close();
+file_put_contents(__DIR__ . '/tts_test.mp3', $response->getAudioContent());
+
+echo "Audio guardado en tests/tts_test.mp3\n";
+


### PR DESCRIPTION
## Summary
- add a simple PHP test script for Google TTS
- document how to run the script

## Testing
- `php -l tests/tts_test.php`
- `php tests/tts_test.php` *(fails: Application Default Credentials not found)*

------
https://chatgpt.com/codex/tasks/task_e_68584068aa5483269b854f4dc20d56fb