### PR TITLE
Quote column names in registerEntry

### DIFF
--- a/process/operations/main.php
+++ b/process/operations/main.php
@@ -164,8 +164,8 @@ function registerEntry($conn, $usn, $user, $category, $branch, $date, $entryTime
     $sl = getsl($conn, "sl", "inout");
     $stmt = $conn->prepare("
         INSERT INTO `inout` (
-            sl, cardnumber, name, gender, date, entry, exit, status,
-            loc, cc, branch, sort1, sort2, email, mob
+            `sl`, `cardnumber`, `name`, `gender`, `date`, `entry`, `exit`, `status`,
+            `loc`, `cc`, `branch`, `sort1`, `sort2`, `email`, `mob`
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ");
     $stmt->bind_param(


### PR DESCRIPTION
## Summary
- ensure column names in `registerEntry` are wrapped with backticks

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858af2be94883268e50488468f6888f