### PR TITLE
Fix dash.php variable check

### DIFF
--- a/dash.php
+++ b/dash.php
@@ -191,7 +191,7 @@ error_reporting(E_ALL);
 				?>
 		    <div class="h1 t-shadow">
 					<?php
-                                                if ($d_status == "OUT" || $d_status == "IN") {
+                                                if (isset($d_status) && ($d_status === 'OUT' || $d_status === 'IN')) {
                                                         $g = new PersonalizedGreeting();
                                                         $timeOfDay = (int)date('G');
                                                         if ($timeOfDay < 12) {


### PR DESCRIPTION
## Summary
- prevent undefined `$d_status` access in `dash.php`

## Testing
- `php tests/tts_test.php` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858b16062bc8326bdd0330b27ff41a8