### PR TITLE
Add DEBUG env handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,6 @@ KOHA_DB_NAME=koha_db
 TTS_CREDENTIALS_PATH=/u01/vhosts/inout.upeu.edu.pe/credentials/inout-tts.json
 TTS_LANGUAGE_CODE=es-ES
 TTS_VOICE=es-ES-Standard-A
+
+# Debugging (set to 1 to show PHP errors)
+DEBUG=0

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Sigue estos pasos para configurar el proyecto en tu entorno local:
         TTS_VOICE=es-ES-Standard-A
         ```
 -   Para verificar tu configuración de TTS, ejecuta `php tests/tts_test.php`. Este script guarda `tests/tts_test.mp3`.
+-   Si deseas ver los mensajes de error de PHP durante el desarrollo, establece `DEBUG=1` en tu archivo `.env`.
 
 
 ## ⚙️ Uso

--- a/dash.php
+++ b/dash.php
@@ -1,9 +1,11 @@
 <?php
 require_once __DIR__ . '/vendor/autoload.php';
 
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
+if (getenv('DEBUG')) {
+    ini_set('display_errors', 1);
+    ini_set('display_startup_errors', 1);
+    error_reporting(E_ALL);
+}
 
 //define('ENV_FILE', '/u01/vhosts/inout.upeu.edu.pe/httpdocs/koha-inout/fronts/koha-inout-lima/.env');
 //require_once ENV_FILE;

--- a/login.php
+++ b/login.php
@@ -2,9 +2,11 @@
   <head>
     <?php
 
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
+if (getenv('DEBUG')) {
+    ini_set('display_errors', 1);
+    ini_set('display_startup_errors', 1);
+    error_reporting(E_ALL);
+}
 
 // 👇 Importante: carga automática de clases
 require_once __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- check DEBUG variable before enabling PHP error display
- document DEBUG env var

## Testing
- `php -l login.php`
- `php -l dash.php`
- `composer install`

------
https://chatgpt.com/codex/tasks/task_e_6858ba090adc8326b202352b53621cb2