### PR TITLE
Add vendor autoload checks

### DIFF
--- a/dash.php
+++ b/dash.php
@@ -1,5 +1,6 @@
 <?php
-require_once __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/functions/autoload_helper.php';
+require_vendor_autoload(__DIR__);
 
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);

--- a/functions/autoload_helper.php
+++ b/functions/autoload_helper.php
@@ -1,0 +1,10 @@
+<?php
+function require_vendor_autoload(string $baseDir): void
+{
+    $autoload = rtrim($baseDir, '/').'/vendor/autoload.php';
+    if (!file_exists($autoload)) {
+        echo 'Vendor autoload not found. Please run "composer install".';
+        exit;
+    }
+    require_once $autoload;
+}

--- a/login.php
+++ b/login.php
@@ -1,3 +1,7 @@
+<?php
+require_once __DIR__ . '/functions/autoload_helper.php';
+require_vendor_autoload(__DIR__);
+?>
 <html lang="en" class="perfect-scrollbar-off">
   <head>
     <?php
@@ -5,9 +9,6 @@
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
-
-// 👇 Importante: carga automática de clases
-require_once __DIR__ . '/vendor/autoload.php';
 
       include './functions/dbconn.php';
     ?>


### PR DESCRIPTION
## Summary
- add helper to require Composer autoload safely
- use the helper in `dash.php`
- use the helper in `login.php`

## Testing
- `php tests/tts_test.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6858ba020274832685fcf5021a28de4e