### PR TITLE
Read DB credentials from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Sigue estos pasos para configurar el proyecto en tu entorno local:
 3.  **Configurar la Base de Datos:**
     -   Crea una base de datos MySQL para el proyecto (ej. `inout_db`).
     -   Importa el esquema de la base de datos. Si no hay un archivo `.sql` provisto, la estructura de la base de datos necesitará ser creada manualmente o a través de un script de instalación que el proyecto pueda tener. (Basado en los archivos, parece que la base de datos se maneja a través de `functions/dbconn.php` y `functions/dbfunc.php`, por lo que necesitarías crearla manualmente o el proyecto debe tener una sección `setup.php` para la configuración inicial).
-    -   Copia el archivo `.env.example` a `.env` y actualiza las credenciales de conexión:
+    -   Copia el archivo `.env.example` a `.env` y actualiza las credenciales de conexión. **Este archivo es obligatorio para que la aplicación pueda conectarse a la base de datos:**
         ```bash
         cp .env.example .env
         # Edita el archivo .env con los datos de tu base de datos

--- a/functions/dbconn.php
+++ b/functions/dbconn.php
@@ -1,24 +1,36 @@
 <?php
 $envPath = dirname(__DIR__) . '/.env';
-$env = [];
-if (file_exists($envPath)) {
-    $env = parse_ini_file($envPath, false, INI_SCANNER_TYPED);
+if (!file_exists($envPath)) {
+    throw new RuntimeException(
+        "Environment file '.env' not found. Copy '.env.example' and configure your database credentials."
+    );
 }
 
-$servername = $env['INOUT_DB_HOST'] ?? 'consola-mariadb';
-$username   = $env['INOUT_DB_USER'] ?? 'Uinoutl';
-$password   = $env['INOUT_DB_PASS'] ?? 'DbL1n0u72023#$';
-$db         = $env['INOUT_DB_NAME'] ?? 'inout_bul';
+$env = parse_ini_file($envPath, false, INI_SCANNER_TYPED);
+
+$requiredInout = ['INOUT_DB_HOST', 'INOUT_DB_USER', 'INOUT_DB_PASS', 'INOUT_DB_NAME'];
+$requiredKoha  = ['KOHA_DB_HOST', 'KOHA_DB_USER', 'KOHA_DB_PASS', 'KOHA_DB_NAME'];
+
+foreach (array_merge($requiredInout, $requiredKoha) as $key) {
+    if (!array_key_exists($key, $env)) {
+        throw new RuntimeException("Missing '{$key}' in .env. Configure your database settings.");
+    }
+}
+
+$servername = $env['INOUT_DB_HOST'];
+$username   = $env['INOUT_DB_USER'];
+$password   = $env['INOUT_DB_PASS'];
+$db         = $env['INOUT_DB_NAME'];
 
 $conn = mysqli_connect($servername, $username, $password, $db);
 if (!$conn) {
     die('Connection failed: ' . mysqli_connect_error($conn));
 }
 
-$kohaServername = $env['KOHA_DB_HOST'] ?? 'consola-mariadb';
-$kohaUsername   = $env['KOHA_DB_USER'] ?? 'koha_bul';
-$kohaPassword   = $env['KOHA_DB_PASS'] ?? 'rP"K)|k#TjQEHs8w';
-$kohaDb         = $env['KOHA_DB_NAME'] ?? 'koha_bul';
+$kohaServername = $env['KOHA_DB_HOST'];
+$kohaUsername   = $env['KOHA_DB_USER'];
+$kohaPassword   = $env['KOHA_DB_PASS'];
+$kohaDb         = $env['KOHA_DB_NAME'];
 
 $koha = mysqli_connect($kohaServername, $kohaUsername, $kohaPassword, $kohaDb);
 if (!$koha) {


### PR DESCRIPTION
## Summary
- load DB connection parameters solely from `.env`
- stop using defaults in `functions/dbconn.php`
- mention in README that `.env` is mandatory for DB configuration

## Testing
- `php -l functions/dbconn.php`
- `php -l tests/tts_test.php`
- `php tests/tts_test.php` *(fails: TTS_CREDENTIALS_PATH not configured)*

------
https://chatgpt.com/codex/tasks/task_e_6858b9fd7a088326aa84406b3c2fe56e