### PR TITLE
Improve db connection error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 blank.php
 vendor/
 test_tts.php
+logs/*
+!logs/.gitkeep

--- a/functions/dbconn.php
+++ b/functions/dbconn.php
@@ -7,14 +7,39 @@ if (!file_exists($envPath)) {
 }
 
 $env = parse_ini_file($envPath, false, INI_SCANNER_TYPED);
+if ($env === false) {
+    throw new RuntimeException("Failed to parse .env file at {$envPath}.");
+}
 
 $requiredInout = ['INOUT_DB_HOST', 'INOUT_DB_USER', 'INOUT_DB_PASS', 'INOUT_DB_NAME'];
 $requiredKoha  = ['KOHA_DB_HOST', 'KOHA_DB_USER', 'KOHA_DB_PASS', 'KOHA_DB_NAME'];
 
 foreach (array_merge($requiredInout, $requiredKoha) as $key) {
-    if (!array_key_exists($key, $env)) {
-        throw new RuntimeException("Missing '{$key}' in .env. Configure your database settings.");
+    if (!array_key_exists($key, $env) || $env[$key] === '') {
+        throw new RuntimeException("Missing or empty '{$key}' in .env. Configure your database settings.");
     }
+}
+
+$debug   = !empty($env['DEBUG']);
+$logFile = dirname(__DIR__) . '/logs/error.log';
+if (!is_dir(dirname($logFile))) {
+    mkdir(dirname($logFile), 0775, true);
+}
+
+/**
+ * Log an error message and display a generic HTML error when debug is disabled.
+ */
+function handleConnectionError(string $message, bool $debug, string $logFile): void
+{
+    $date = date('c');
+    file_put_contents($logFile, "[$date] $message\n", FILE_APPEND);
+
+    if ($debug) {
+        throw new RuntimeException($message);
+    }
+
+    echo '<p>Database connection error. Please contact the administrator.</p>';
+    exit;
 }
 
 $servername = $env['INOUT_DB_HOST'];
@@ -24,7 +49,7 @@ $db         = $env['INOUT_DB_NAME'];
 
 $conn = mysqli_connect($servername, $username, $password, $db);
 if (!$conn) {
-    die('Connection failed (' . mysqli_connect_errno() . '): ' . mysqli_connect_error());
+    handleConnectionError('InOut DB connection failed (' . mysqli_connect_errno() . '): ' . mysqli_connect_error(), $debug, $logFile);
 }
 
 $kohaServername = $env['KOHA_DB_HOST'];
@@ -34,7 +59,7 @@ $kohaDb         = $env['KOHA_DB_NAME'];
 
 $koha = mysqli_connect($kohaServername, $kohaUsername, $kohaPassword, $kohaDb);
 if (!$koha) {
-    die('Connection failed (' . mysqli_connect_errno() . '): ' . mysqli_connect_error());
+    handleConnectionError('Koha DB connection failed (' . mysqli_connect_errno() . '): ' . mysqli_connect_error(), $debug, $logFile);
 }
 
 function sanitize($conn, $str)


### PR DESCRIPTION
## Summary
- handle db connection errors via exception and logging
- ensure .env values exist and are not empty
- track logs via gitkeep

## Testing
- `php -l functions/dbconn.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68598115f5888326b31313385ec1c013