### PR TITLE
Fix GET param handling in edit pages

### DIFF
--- a/edit_role.php
+++ b/edit_role.php
@@ -15,8 +15,9 @@
 	  <div class="row">
 	    <div class="col-md-6 ml-auto mr-auto">
 	    	<?php
-	    	if(isset($_GET['editrole'])) {
-	    		$res = getDataById($conn, "roles", $_GET['editrole']);
+                if(isset($_GET['editrole'])) {
+                        $roleId = (int) $_GET['editrole'];
+                        $res = getDataById($conn, "roles", $roleId);
 				$row = mysqli_fetch_array($res);
 				$section = explode(';',$row[3]);
 			?>

--- a/edit_user.php
+++ b/edit_user.php
@@ -23,10 +23,11 @@
               <h4 class="card-title">Edit User</h4>
           	</div>
 					  <div class="card-body">
-				    	<?php
-				    		if(isset($_GET['edituser'])) {
-				    			$res = getDataById($conn, "users", $_GET['edituser']);
-								$row = mysqli_fetch_array($res);
+                                        <?php
+                                                if(isset($_GET['edituser'])) {
+                                                        $userId = (int) $_GET['edituser'];
+                                                        $res = getDataById($conn, "users", $userId);
+                                                                $row = mysqli_fetch_array($res);
 							?>
 							<form name="form4" action="process/admin/usr_process.php" method="POST">
 		        		<div class="form-group bmd-form-group">


### PR DESCRIPTION
## Summary
- cast `$_GET` parameters to integers before calling `getDataById`

## Testing
- `composer install`
- `php -l edit_role.php`
- `php -l edit_user.php`


------
https://chatgpt.com/codex/tasks/task_e_68598692b8448326b5cf32779b12d609