### PR TITLE
Document deployment requirement

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,10 @@
+# Deployment Steps
+
+To deploy the InOut system on a new server:
+
+1. Copy all files to the web root of the target server.
+2. Run `composer install` inside the project root to generate the `vendor/` directory. This step is required because `login.php` checks for `vendor/autoload.php` and will exit with the message "Vendor autoload not found" if it is missing.
+3. Configure your `.env` file with the database credentials and other settings.
+4. Make sure the web server user can read the application files and write to any directories that require write access (such as `logs/`).
+
+These steps complement the installation instructions in `README.md` and ensure that the application boots correctly in production.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Sigue estos pasos para configurar el proyecto en tu entorno local:
 4.  **Desplegar en el Servidor Web:**
     -   Copia todos los archivos del proyecto al directorio raíz de tu servidor web (ej. `htdocs` para Apache o `www` para Nginx).
     -   En cada entorno donde despliegues el proyecto debes ejecutar `composer install` para generar el directorio `vendor/`. Si este paso se omite, páginas como `login.php` terminarán con el mensaje **"Vendor autoload not found"**.
+    -   Consulta el archivo `DEPLOYMENT.md` para ver un resumen de los pasos necesarios en producción.
 
 5.  **Acceder al Sistema:**
     -   Abre tu navegador y navega a la URL donde desplegaste el proyecto (ej. `http://localhost/inout` o `http://tu_dominio/`).


### PR DESCRIPTION
## Summary
- add deployment notes to README
- create `DEPLOYMENT.md` with concise deployment instructions

## Testing
- `php tests/vendor_test.php` *(fails: No se encontró el archivo de credenciales)*
- `php tests/tts_test.php` *(fails: TTS_CREDENTIALS_PATH no está configurado)*
- `php -l login.php`

------
https://chatgpt.com/codex/tasks/task_e_6859868c881c8326b9a9fa906901d415