### PR TITLE
Explain bind_param type string

### DIFF
--- a/process/operations/main.php
+++ b/process/operations/main.php
@@ -168,8 +168,12 @@ function registerEntry($conn, $usn, $user, $category, $branch, $date, $entryTime
             `loc`, `cc`, `branch`, `sort1`, `sort2`, `email`, `mob`
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ");
+    // 'i' indicates the first parameter ($sl) is an integer and the
+    // remaining 14 placeholders expect strings. Building the type string
+    // dynamically improves readability.
+    $typeString = 'i' . str_repeat('s', 14);
     $stmt->bind_param(
-        'issssssssssssss',
+        $typeString,
         $sl,
         $usn,
         $user['fullname'],


### PR DESCRIPTION
## Summary
- document the meaning of the `issssssssssssss` bind string in `registerEntry`
- build the type string dynamically for clarity

## Testing
- `php -l process/operations/main.php` *(fails: `php` not installed)*
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b20ccb188326af61a06e48d17697