### PR TITLE
Improve TTS credentials check

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Si encuentras algún problema durante la instalación o el uso, considera los si
 -   **Errores de Conexión a la Base de Datos:** Asegúrate de que el archivo `.env` contenga las credenciales correctas y que tu servidor MySQL esté en ejecución.
 -   **Permisos de Archivos:** Asegúrate de que el servidor web tenga los permisos necesarios para leer los archivos del proyecto y escribir en los directorios si es necesario (ej. para backups).
 -   **Errores de PHP:** Revisa los logs de errores de tu servidor web para obtener detalles sobre cualquier problema de PHP.
+-   **Credenciales TTS no legibles:** Si el archivo indicado en `TTS_CREDENTIALS_PATH` no existe o no tiene permisos de lectura, la aplicación mostrará una excepción indicando esa variable.
 -   **Páginas en Blanco:** Si ves una página en blanco, puede ser un error de PHP no mostrado. Habilita `display_errors` en tu `php.ini` temporalmente para ver los mensajes de error.
 
 ## 📜 Licencia

--- a/functions/PersonalizedGreeting.php
+++ b/functions/PersonalizedGreeting.php
@@ -38,7 +38,8 @@ class PersonalizedGreeting
 
         if (empty($this->credentialsPath) || !is_readable($this->credentialsPath)) {
             throw new RuntimeException(
-                "Text-to-Speech credentials file not found or unreadable at '{$this->credentialsPath}'."
+                "Text-to-Speech credentials file not found or unreadable at '{$this->credentialsPath}'. "
+                . 'Check the TTS_CREDENTIALS_PATH variable.'
             );
         }
     }


### PR DESCRIPTION
## Summary
- mention `TTS_CREDENTIALS_PATH` in the missing credentials error
- add troubleshooting note for unreadable credentials

## Testing
- `php tests/tts_test.php`
- `php tests/env_check.php`
- `php tests/vendor_test.php`


------
https://chatgpt.com/codex/tasks/task_e_6859b1efb754832699e6b4c94ade9e6a