### PR TITLE
Add handleAttendance function and test

### DIFF
--- a/functions/Attendance.php
+++ b/functions/Attendance.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Minimal attendance handling using a simple IN/OUT toggle.
+ * This helper works with PDO and expects a table called `inout` with
+ * columns: id INTEGER PRIMARY KEY AUTOINCREMENT, cardnumber TEXT,
+ * entry INTEGER, exit INTEGER, status TEXT.
+ */
+function handleAttendance(PDO $db, string $cardNumber, int $timestamp = null): string
+{
+    $timestamp = $timestamp ?? time();
+
+    // Get last record for this card number
+    $stmt = $db->prepare('SELECT * FROM inout WHERE cardnumber = ? ORDER BY id DESC LIMIT 1');
+    $stmt->execute([$cardNumber]);
+    $last = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$last || $last['status'] === 'OUT') {
+        // New entry
+        $insert = $db->prepare('INSERT INTO inout(cardnumber, entry, status) VALUES (?, ?, "IN")');
+        $insert->execute([$cardNumber, $timestamp]);
+        return 'IN';
+    }
+
+    // Last status is IN
+    $entryTime = (int)$last['entry'];
+    if ($timestamp - $entryTime >= 10) {
+        $update = $db->prepare('UPDATE inout SET exit = ?, status = "OUT" WHERE id = ?');
+        $update->execute([$timestamp, $last['id']]);
+        return 'OUT';
+    }
+
+    // Ignore if scanned again too quickly
+    return $last['status'];
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
     <testsuites>
         <testsuite name="InOut Test Suite">
             <directory>./tests</directory>

--- a/tests/HandleAttendanceTest.php
+++ b/tests/HandleAttendanceTest.php
@@ -1,0 +1,35 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../functions/Attendance.php';
+
+class HandleAttendanceTest extends TestCase
+{
+    private PDO $db;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->db->exec("CREATE TABLE inout (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            cardnumber TEXT,
+            entry INTEGER,
+            exit INTEGER,
+            status TEXT
+        )");
+    }
+
+    public function testSuccessiveScansAlternateStatus(): void
+    {
+        $start = 1000;
+        $this->assertSame('IN', handleAttendance($this->db, 'A1', $start));
+        $this->assertSame('OUT', handleAttendance($this->db, 'A1', $start + 10));
+        $this->assertSame('IN', handleAttendance($this->db, 'A1', $start + 20));
+        $this->assertSame('OUT', handleAttendance($this->db, 'A1', $start + 30));
+
+        $stmt = $this->db->query('SELECT status FROM inout ORDER BY id');
+        $statuses = $stmt->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertSame(['OUT', 'OUT'], $statuses);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,10 @@
+<?php
+$autoloader = __DIR__ . '/../vendor/autoload.php';
+if (!file_exists($autoloader)) {
+    // Create a minimal stub so files expecting the autoloader do not fail
+    if (!is_dir(dirname($autoloader))) {
+        mkdir(dirname($autoloader), 0775, true);
+    }
+    file_put_contents($autoloader, "<?php\n// stub autoloader for tests\n");
+}
+require_once $autoloader;


### PR DESCRIPTION
## Summary
- add new `handleAttendance` function for IN/OUT toggling
- create test with in‑memory database to verify alternating statuses
- bootstrap PHPUnit without requiring full vendor install
- update phpunit.xml to use new bootstrap file

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6859c488aac083269c657d9d8d55ec4c