### PR TITLE
Remove GOOGLE_APPLICATION_CREDENTIALS var

### DIFF
--- a/.env
+++ b/.env
@@ -11,7 +11,6 @@ KOHA_DB_PASS='rP"K)|k#TjQEHs8w'
 KOHA_DB_NAME=koha_bul
 
 # Google Cloud Text-to-Speech
-GOOGLE_APPLICATION_CREDENTIALS=/u01/vhosts/inout.upeu.edu.pe/credentials/inout-koha-biblioteca-4b30dc340941.json
 TTS_CREDENTIALS_PATH=/u01/vhosts/inout.upeu.edu.pe/credentials/inout-koha-biblioteca-4b30dc340941.json
 
 TTS_LANGUAGE_CODE=es-ES

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -8,7 +8,6 @@ To deploy the InOut system on a new server:
    - `INOUT_DB_HOST`, `INOUT_DB_USER`, `INOUT_DB_PASS`, `INOUT_DB_NAME`
    - `KOHA_DB_HOST`, `KOHA_DB_USER`, `KOHA_DB_PASS`, `KOHA_DB_NAME`
    - `TTS_CREDENTIALS_PATH`, `TTS_LANGUAGE_CODE`, `TTS_VOICE`
-     (optionally `GOOGLE_APPLICATION_CREDENTIALS` if the Google library needs it)
    Ensure the web server user can read this file by running `ls -l .env`.
 4. Make sure the web server user can read the application files and write to any directories that require write access (such as `logs/`).
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ Sigue estos pasos para configurar el proyecto en tu entorno local:
         TTS_LANGUAGE_CODE=es-ES
         TTS_VOICE=es-ES-Standard-A
         ```
--   Como verificación rápida, ejecuta `php tests/tts_test.php` después de definir las variables TTS. Este script creará `tests/tts_test.mp3` si las credenciales y dependencias de Google TTS están instaladas correctamente.
+    -   No es necesario establecer `GOOGLE_APPLICATION_CREDENTIALS`; la clase de saludo pasa la ruta de las credenciales directamente a la biblioteca de Google.
+    -   Como verificación rápida, ejecuta `php tests/tts_test.php` después de definir las variables TTS. Este script creará `tests/tts_test.mp3` si las credenciales y dependencias de Google TTS están instaladas correctamente.
 -   Si deseas ver los mensajes de error de PHP durante el desarrollo, establece `DEBUG=1` en tu archivo `.env`.
 
 

--- a/tests/tts_test.php
+++ b/tests/tts_test.php
@@ -15,8 +15,6 @@ if (!$credentials) {
     exit(1);
 }
 
-putenv('GOOGLE_APPLICATION_CREDENTIALS=' . $credentials);
-
 use Google\Cloud\TextToSpeech\V1\Client\TextToSpeechClient;
 use Google\Cloud\TextToSpeech\V1\SynthesisInput;
 use Google\Cloud\TextToSpeech\V1\VoiceSelectionParams;

--- a/tests/vendor_test.php
+++ b/tests/vendor_test.php
@@ -16,11 +16,11 @@ if (!file_exists($credentialsPath)) {
     exit(1);
 }
 
-// Establecer la variable de entorno para GCP
-putenv("GOOGLE_APPLICATION_CREDENTIALS={$credentialsPath}");
-
 try {
-    $client = new TextToSpeechClient();
+    // Pasar las credenciales directamente al cliente
+    $client = new TextToSpeechClient([
+        'credentials' => $credentialsPath,
+    ]);
     echo "✅ Google Cloud TextToSpeechClient cargado correctamente." . PHP_EOL;
 } catch (Throwable $e) {
     echo "❌ Error: " . $e->getMessage() . PHP_EOL;


### PR DESCRIPTION
## Summary
- clean `.env` to use only `TTS_CREDENTIALS_PATH`
- note new variable usage in README and deployment docs
- update TTS tests to pass credentials directly

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: PDOException could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_6859c7dd97b083268ee6d0ec729e7112