### PR TITLE
Load DB early in login page and toggle error display

### DIFF
--- a/login.php
+++ b/login.php
@@ -2,15 +2,15 @@
 
 require_once __DIR__ . '/functions/autoload_helper.php';
 require_vendor_autoload(__DIR__);
+require_once __DIR__ . '/functions/dbconn.php';
 
 // Mostrar errores si DEBUG está activo
-if (getenv('DEBUG')) {
+$debug = $_ENV['DEBUG'] ?? getenv('DEBUG');
+if ($debug) {
     ini_set('display_errors', 1);
     ini_set('display_startup_errors', 1);
     error_reporting(E_ALL);
 }
-
-require_once './functions/dbconn.php';
 date_default_timezone_set("America/Lima");
 
 // Obtener lista de ubicaciones


### PR DESCRIPTION
## Summary
- require the DB connection right after vendor autoload
- use `$_ENV['DEBUG']` or `getenv('DEBUG')` to enable PHP error display

## Testing
- `phpunit --configuration phpunit.xml tests` *(fails: could not find driver)*
- `DEBUG=1 php login.php` *(fails: Dotenv\Dotenv not found, error displayed)*

------
https://chatgpt.com/codex/tasks/task_e_6859c7c98264832686c97cf7c3e54abc