### PR TITLE
Ensure GOOGLE_APPLICATION_CREDENTIALS is required

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ KOHA_DB_USER=your_koha_user
 KOHA_DB_PASS=your_koha_pass
 KOHA_DB_NAME=koha_db
 
-# Google Cloud Text-to-Speech
+# Google Cloud Text-to-Speech - path to your credentials JSON file (required)
 GOOGLE_APPLICATION_CREDENTIALS=/u01/vhosts/inout.upeu.edu.pe/credentials/inout-tts.json
 TTS_LANGUAGE_CODE=es-ES
 TTS_VOICE=es-ES-Standard-A

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -9,6 +9,8 @@ To deploy the InOut system on a new server:
    - `KOHA_DB_HOST`, `KOHA_DB_USER`, `KOHA_DB_PASS`, `KOHA_DB_NAME`
    - `GOOGLE_APPLICATION_CREDENTIALS`, `TTS_LANGUAGE_CODE`, `TTS_VOICE`
    Ensure the web server user can read this file by running `ls -l .env`.
+   If `GOOGLE_APPLICATION_CREDENTIALS` is not defined the application will
+   throw a runtime exception during startup.
 4. Make sure the web server user can read the application files and write to any directories that require write access (such as `logs/`).
 
 These steps complement the installation instructions in `README.md` and ensure that the application boots correctly in production.

--- a/functions/dbconn.php
+++ b/functions/dbconn.php
@@ -9,7 +9,8 @@ $dotenv->load();
 
 $required = [
     'INOUT_DB_HOST', 'INOUT_DB_USER', 'INOUT_DB_PASS', 'INOUT_DB_NAME',
-    'KOHA_DB_HOST', 'KOHA_DB_USER', 'KOHA_DB_PASS', 'KOHA_DB_NAME'
+    'KOHA_DB_HOST', 'KOHA_DB_USER', 'KOHA_DB_PASS', 'KOHA_DB_NAME',
+    'GOOGLE_APPLICATION_CREDENTIALS'
 ];
 
 foreach ($required as $key) {


### PR DESCRIPTION
## Summary
- check GOOGLE_APPLICATION_CREDENTIALS in dbconn.php
- document requirement in `.env.example`
- note runtime exception in DEPLOYMENT.md

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685a137b9c508326b238ee11296d9c90