### PR TITLE
Remove leftover ob_start calls

### DIFF
--- a/backup.php
+++ b/backup.php
@@ -1,6 +1,5 @@
 <?php
   session_start();
-  // ob_start(ob_gzhandler);
   $title = "Backup";
   $acc_code = "R01";
   require "./functions/access.php";

--- a/blank.php
+++ b/blank.php
@@ -1,6 +1,5 @@
 <?php
 	session_start();
-	// ob_start(ob_gzhandler);
 	$title = "Dashboard";
 	$acc_code = "";
 	require "./functions/access.php";

--- a/edit_role.php
+++ b/edit_role.php
@@ -1,6 +1,5 @@
 <?php
 	session_start();
-	// ob_start(ob_gzhandler);
 	$title = "Edit Role";
 	$acc_code = "A02";
 	require "./functions/access.php";

--- a/edit_user.php
+++ b/edit_user.php
@@ -1,6 +1,5 @@
 <?php
 	session_start();	
-	// ob_start(ob_gzhandler);
 	$title = "Edit Role";
 	$acc_code = "A02";
 	require "./functions/access.php";

--- a/report.php
+++ b/report.php
@@ -1,6 +1,5 @@
 <?php
 	session_start();
-	// ob_start(ob_gzhandler);
 	$title = "Report";
 	$acc_code = "R01";
 	$table = true;

--- a/reports.php
+++ b/reports.php
@@ -1,6 +1,5 @@
 <?php
 	session_start();
-	// ob_start(ob_gzhandler);
 	$title = "Reports";
 	$acc_code = "";
 	// $acc_code = "R01";

--- a/setup.php
+++ b/setup.php
@@ -1,6 +1,5 @@
 <?php
 	session_start();
-	// ob_start(ob_gzhandler);
 	$title = "Setup";
 	// $acc_code = "S01";
 	$acc_code = "S01";

--- a/user_mgnt.php
+++ b/user_mgnt.php
@@ -1,6 +1,5 @@
 <?php
 	session_start();
-	// ob_start(ob_gzhandler);
 	$title = "User Management";
 	$acc_code = "A02";
 	require "./functions/access.php";


### PR DESCRIPTION
## Summary
- clean up commented ob_start statements in top-level pages

## Testing
- `php -l backup.php`
- `php -l blank.php`
- `php -l edit_role.php`
- `php -l edit_user.php`
- `php -l report.php`
- `php -l reports.php`
- `php -l setup.php`
- `php -l user_mgnt.php`
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a45ba6c1c8326a8a91328fe1e0863