### PR TITLE
Add env loader and unify dotenv

### DIFF
--- a/functions/PersonalizedGreeting.php
+++ b/functions/PersonalizedGreeting.php
@@ -2,16 +2,14 @@
 
 declare(strict_types=1);
 
-// Se asegura de que el cargador de Composer esté disponible.
-// La ruta es relativa al directorio del script que instancia esta clase.
-require_once dirname(__DIR__) . '/vendor/autoload.php';
+// Se asegura de que el cargador de Composer esté disponible y las variables de entorno cargadas.
+require_once __DIR__ . '/env_loader.php';
 
 use Google\Cloud\TextToSpeech\V1\AudioConfig;
 use Google\Cloud\TextToSpeech\V1\AudioEncoding;
 use Google\Cloud\TextToSpeech\V1\SynthesisInput;
 use Google\Cloud\TextToSpeech\V1\TextToSpeechClient;
 use Google\Cloud\TextToSpeech\V1\VoiceSelectionParams;
-use Dotenv\Dotenv;
 
 /**
  * Gestiona la creación y síntesis de saludos de voz personalizados
@@ -40,10 +38,7 @@ class PersonalizedGreeting
      */
     public function __construct()
     {
-        // Carga las variables de entorno desde el directorio raíz del proyecto.
-        $dotenv = Dotenv::createImmutable(dirname(__DIR__));
-        $dotenv->load();
-
+        // Las variables de entorno ya están disponibles por env_loader.php
         $this->credentialsPath = $_ENV['GOOGLE_APPLICATION_CREDENTIALS'] ?? '';
         $this->languageCode = $_ENV['TTS_LANGUAGE_CODE'] ?? 'es-ES';
         $this->voiceName = $_ENV['TTS_VOICE'] ?? null;

--- a/functions/dbconn.php
+++ b/functions/dbconn.php
@@ -1,11 +1,5 @@
 <?php
-require_once __DIR__ . '/../vendor/autoload.php';
-
-use Dotenv\Dotenv;
-
-// Cargar el archivo .env de la raíz del proyecto
-$dotenv = Dotenv::createImmutable(dirname(__DIR__));
-$dotenv->load();
+require_once __DIR__ . '/env_loader.php';
 
 $required = [
     'INOUT_DB_HOST', 'INOUT_DB_USER', 'INOUT_DB_PASS', 'INOUT_DB_NAME',

--- a/functions/env_loader.php
+++ b/functions/env_loader.php
@@ -1,0 +1,32 @@
+<?php
+if (!defined('ENV_LOADER')) {
+    require_once __DIR__ . '/autoload_helper.php';
+    require_vendor_autoload(dirname(__DIR__));
+
+    use Dotenv\Dotenv;
+
+    $dotenv = Dotenv::createImmutable(dirname(__DIR__));
+    $dotenv->load();
+
+    $required = [
+        'INOUT_DB_HOST', 'INOUT_DB_USER', 'INOUT_DB_PASS', 'INOUT_DB_NAME',
+        'KOHA_DB_HOST', 'KOHA_DB_USER', 'KOHA_DB_PASS', 'KOHA_DB_NAME',
+        'GOOGLE_APPLICATION_CREDENTIALS'
+    ];
+
+    foreach ($required as $var) {
+        if (!isset($_ENV[$var]) || trim($_ENV[$var]) === '') {
+            throw new RuntimeException("❌ Falta la variable de entorno: {$var}");
+        }
+    }
+
+    $credPath = $_ENV['GOOGLE_APPLICATION_CREDENTIALS'];
+    if (!is_readable($credPath)) {
+        throw new RuntimeException(
+            "El archivo de credenciales para Text-to-Speech no se encontró o no se puede leer en '{$credPath}'."
+        );
+    }
+
+    define('ENV_LOADER', true);
+}
+?>

--- a/index.php
+++ b/index.php
@@ -2,12 +2,7 @@
 
 require_once __DIR__ . '/functions/autoload_helper.php';
 require_vendor_autoload(__DIR__);
-
-use Dotenv\Dotenv;
-
-// Cargar variables de entorno antes de revisar el modo DEBUG
-$dotenv = Dotenv::createImmutable(__DIR__);
-$dotenv->load();
+require_once __DIR__ . '/functions/env_loader.php';
 
 // --- LÍNEAS DE DEPURACIÓN ---
 $debug = $_ENV['DEBUG'] ?? getenv('DEBUG');

--- a/login.php
+++ b/login.php
@@ -2,6 +2,7 @@
 
 require_once __DIR__ . '/functions/autoload_helper.php';
 require_vendor_autoload(__DIR__);
+require_once __DIR__ . '/functions/env_loader.php';
 require_once __DIR__ . '/functions/dbconn.php';
 
 // Mostrar errores si DEBUG está activo


### PR DESCRIPTION
## Summary
- centralize dotenv loading in new `env_loader.php`
- load environment in DB connector and scripts via helper
- remove duplicated Dotenv code in `index.php`, `login.php` and greeting class

## Testing
- `php -l functions/env_loader.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a45b9cda8832682cd84de66b75415