### PR TITLE
Set charset after DB connect

### DIFF
--- a/functions/dbconn.php
+++ b/functions/dbconn.php
@@ -43,10 +43,26 @@ if (!$conn) {
     handleConnectionError('❌ Falló la conexión a la DB InOut: ' . mysqli_connect_error(), $debug, $logFile);
 }
 
+if (!mysqli_set_charset($conn, 'utf8mb4')) {
+    handleConnectionError(
+        '❌ No se pudo establecer el conjunto de caracteres utf8mb4 en la DB InOut: ' . mysqli_error($conn),
+        $debug,
+        $logFile
+    );
+}
+
 // Conexión a la base de datos Koha
 $koha = mysqli_connect($_ENV['KOHA_DB_HOST'], $_ENV['KOHA_DB_USER'], $_ENV['KOHA_DB_PASS'], $_ENV['KOHA_DB_NAME']);
 if (!$koha) {
     handleConnectionError('❌ Falló la conexión a la DB Koha: ' . mysqli_connect_error(), $debug, $logFile);
+}
+
+if (!mysqli_set_charset($koha, 'utf8mb4')) {
+    handleConnectionError(
+        '❌ No se pudo establecer el conjunto de caracteres utf8mb4 en la DB Koha: ' . mysqli_error($koha),
+        $debug,
+        $logFile
+    );
 }
 
 function sanitize($conn, $str)


### PR DESCRIPTION
## Summary
- ensure utf8mb4 charset after connecting to InOut and Koha databases

## Testing
- `composer validate --no-check-publish`
- `php -l functions/dbconn.php`


------
https://chatgpt.com/codex/tasks/task_e_685a5581fb108326a423fe2ce8cf0dfd