### PR TITLE
Handle missing Composer autoload gracefully

### DIFF
--- a/functions/autoload_helper.php
+++ b/functions/autoload_helper.php
@@ -3,8 +3,9 @@ function require_vendor_autoload(string $baseDir): void
 {
     $autoload = rtrim($baseDir, '/').'/vendor/autoload.php';
     if (!file_exists($autoload)) {
-        echo 'Vendor autoload not found. Please run "composer install".';
-        exit;
+        throw new RuntimeException(
+            'Vendor autoload not found. Please run "composer install".'
+        );
     }
     require_once $autoload;
 }

--- a/index.php
+++ b/index.php
@@ -1,8 +1,14 @@
 <?php
 
 require_once __DIR__ . '/functions/autoload_helper.php';
-require_vendor_autoload(__DIR__);
-require_once __DIR__ . '/functions/env_loader.php';
+
+try {
+    require_vendor_autoload(__DIR__);
+    require_once __DIR__ . '/functions/env_loader.php';
+} catch (RuntimeException $e) {
+    echo $e->getMessage();
+    exit(1);
+}
 
 // --- LÍNEAS DE DEPURACIÓN ---
 $debug = $_ENV['DEBUG'] ?? getenv('DEBUG');

--- a/login.php
+++ b/login.php
@@ -1,9 +1,15 @@
 <?php
 
 require_once __DIR__ . '/functions/autoload_helper.php';
-require_vendor_autoload(__DIR__);
-require_once __DIR__ . '/functions/env_loader.php';
-require_once __DIR__ . '/functions/dbconn.php';
+
+try {
+    require_vendor_autoload(__DIR__);
+    require_once __DIR__ . '/functions/env_loader.php';
+    require_once __DIR__ . '/functions/dbconn.php';
+} catch (RuntimeException $e) {
+    echo $e->getMessage();
+    exit(1);
+}
 
 // Mostrar errores si DEBUG está activo
 $debug = $_ENV['DEBUG'] ?? getenv('DEBUG');

--- a/process/operations/main.php
+++ b/process/operations/main.php
@@ -7,8 +7,16 @@
 // --- INICIO DEL BLOQUE DE ARRANQUE ---
 // Carga el entorno de la aplicación, incluyendo Composer y helpers.
 require_once dirname(__DIR__, 2) . '/functions/autoload_helper.php';
-require_vendor_autoload(dirname(__DIR__, 2));
-require_once dirname(__DIR__, 2) . '/functions/general.php';
+
+try {
+    require_vendor_autoload(dirname(__DIR__, 2));
+    require_once dirname(__DIR__, 2) . '/functions/general.php';
+} catch (RuntimeException $e) {
+    header('Content-Type: application/json');
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => $e->getMessage()]);
+    exit(1);
+}
 
 // Habilitar que MySQLi lance excepciones en lugar de solo advertencias.
 // Esto permite que nuestro bloque try-catch atrape errores de conexión.


### PR DESCRIPTION
## Summary
- throw a `RuntimeException` when `vendor/autoload.php` is missing
- wrap startup logic of public scripts in try-catch blocks to show errors without abrupt termination

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a5585bd588326b22cfa69d9507734