### PR TITLE
Fix duplicate credentials check

### DIFF
--- a/functions/dbconn.php
+++ b/functions/dbconn.php
@@ -13,10 +13,6 @@ foreach ($required as $key) {
     }
 }
 
-if (!isset($_ENV['GOOGLE_APPLICATION_CREDENTIALS']) || trim($_ENV['GOOGLE_APPLICATION_CREDENTIALS']) === '') {
-    throw new RuntimeException('❌ Falta la variable de entorno: GOOGLE_APPLICATION_CREDENTIALS');
-}
-
 // Configuración de logs y depuración
 $debug = isset($_ENV['DEBUG']) && $_ENV['DEBUG'] == 1;
 $logFile = dirname(__DIR__) . '/logs/error.log';


### PR DESCRIPTION
## Summary
- remove redundant check for `GOOGLE_APPLICATION_CREDENTIALS`

## Testing
- `php -l functions/dbconn.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a59e810a48326838651418fb210e7