### PR TITLE
Improve DB connection error handling

### DIFF
--- a/functions/dbconn.php
+++ b/functions/dbconn.php
@@ -24,29 +24,24 @@ if (!is_dir(dirname($logFile))) {
     mkdir(dirname($logFile), 0775, true);
 }
 
-function handleConnectionError(string $message, bool $debug, string $logFile): void
+function handleConnectionError(string $message, string $logFile): void
 {
     $date = date('c');
     file_put_contents($logFile, "[$date] $message\n", FILE_APPEND);
 
-    if ($debug) {
-        throw new RuntimeException($message);
-    }
-
-    echo '<p>Error de conexión a la base de datos. Contacte al administrador.</p>';
-    exit;
+    // Siempre lanzar una excepción para que los llamadores manejen el error.
+    throw new RuntimeException($message);
 }
 
 // Conexión a la base de datos InOut
 $conn = mysqli_connect($_ENV['INOUT_DB_HOST'], $_ENV['INOUT_DB_USER'], $_ENV['INOUT_DB_PASS'], $_ENV['INOUT_DB_NAME']);
 if (!$conn) {
-    handleConnectionError('❌ Falló la conexión a la DB InOut: ' . mysqli_connect_error(), $debug, $logFile);
+    handleConnectionError('❌ Falló la conexión a la DB InOut: ' . mysqli_connect_error(), $logFile);
 }
 
 if (!mysqli_set_charset($conn, 'utf8mb4')) {
     handleConnectionError(
         '❌ No se pudo establecer el conjunto de caracteres utf8mb4 en la DB InOut: ' . mysqli_error($conn),
-        $debug,
         $logFile
     );
 }
@@ -54,13 +49,12 @@ if (!mysqli_set_charset($conn, 'utf8mb4')) {
 // Conexión a la base de datos Koha
 $koha = mysqli_connect($_ENV['KOHA_DB_HOST'], $_ENV['KOHA_DB_USER'], $_ENV['KOHA_DB_PASS'], $_ENV['KOHA_DB_NAME']);
 if (!$koha) {
-    handleConnectionError('❌ Falló la conexión a la DB Koha: ' . mysqli_connect_error(), $debug, $logFile);
+    handleConnectionError('❌ Falló la conexión a la DB Koha: ' . mysqli_connect_error(), $logFile);
 }
 
 if (!mysqli_set_charset($koha, 'utf8mb4')) {
     handleConnectionError(
         '❌ No se pudo establecer el conjunto de caracteres utf8mb4 en la DB Koha: ' . mysqli_error($koha),
-        $debug,
         $logFile
     );
 }

--- a/index.php
+++ b/index.php
@@ -6,7 +6,8 @@ try {
     require_vendor_autoload(__DIR__);
     require_once __DIR__ . '/functions/env_loader.php';
 } catch (RuntimeException $e) {
-    echo $e->getMessage();
+    http_response_code(500);
+    echo '<p>Ocurri\xC3\xB3 un error al iniciar la aplicaci\xC3\xB3n. Por favor, intente m\xC3\xA1s tarde.</p>';
     exit(1);
 }
 

--- a/login.php
+++ b/login.php
@@ -7,7 +7,8 @@ try {
     require_once __DIR__ . '/functions/env_loader.php';
     require_once __DIR__ . '/functions/dbconn.php';
 } catch (RuntimeException $e) {
-    echo $e->getMessage();
+    http_response_code(500);
+    echo '<p>Ocurri\xC3\xB3 un problema al conectar con el servidor. Intente m\xC3\xA1s tarde.</p>';
     exit(1);
 }
 

--- a/process/operations/main.php
+++ b/process/operations/main.php
@@ -14,7 +14,7 @@ try {
 } catch (RuntimeException $e) {
     header('Content-Type: application/json');
     http_response_code(500);
-    echo json_encode(['success' => false, 'message' => $e->getMessage()]);
+    echo json_encode(['success' => false, 'message' => 'Ocurri\xC3\xB3 un problema en el servidor. Intente m\xC3\xA1s tarde.']);
     exit(1);
 }
 
@@ -113,7 +113,13 @@ try {
     error_log("Error en API de asistencia (main.php): " . $e->getMessage());
 
     // Preparar un mensaje amigable para el usuario.
-    $response['message'] = $e instanceof InvalidArgumentException ? $e->getMessage() : 'Error: ' . $e->getMessage();
+    if ($e instanceof InvalidArgumentException) {
+        $response['message'] = $e->getMessage();
+    } elseif ($e instanceof RuntimeException) {
+        $response['message'] = 'Ocurri\xC3\xB3 un problema en el servidor. Intente m\xC3\xA1s tarde.';
+    } else {
+        $response['message'] = 'Error: ' . $e->getMessage();
+    }
     
     // Establecer el código de estado HTTP a 500 para indicar un error de servidor.
     http_response_code(500);


### PR DESCRIPTION
## Summary
- always throw RuntimeException inside `handleConnectionError()`
- adjust calls to new signature
- show friendly messages when DB connection fails in `login.php`, `index.php`, and operations API
- return generic JSON message for errors in `process/operations/main.php`

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a59e8fb888326b8510e60d0733be9