### PR TITLE
Handle DB connection errors via exceptions

### DIFF
--- a/functions/dbconn.php
+++ b/functions/dbconn.php
@@ -29,12 +29,8 @@ function handleConnectionError(string $message, bool $debug, string $logFile): v
     $date = date('c');
     file_put_contents($logFile, "[$date] $message\n", FILE_APPEND);
 
-    if ($debug) {
-        throw new RuntimeException($message);
-    }
-
-    echo '<p>Error de conexión a la base de datos. Contacte al administrador.</p>';
-    exit;
+    $userMessage = $debug ? $message : 'Error de conexión a la base de datos. Contacte al administrador.';
+    throw new RuntimeException($userMessage);
 }
 
 // Conexión a la base de datos InOut

--- a/index.php
+++ b/index.php
@@ -4,9 +4,9 @@ require_once __DIR__ . '/functions/autoload_helper.php';
 
 try {
     require_vendor_autoload(__DIR__);
-    require_once __DIR__ . '/functions/env_loader.php';
+require_once __DIR__ . '/functions/env_loader.php';
 } catch (RuntimeException $e) {
-    echo $e->getMessage();
+    echo '<p>' . htmlspecialchars($e->getMessage()) . '</p>';
     exit(1);
 }
 

--- a/login.php
+++ b/login.php
@@ -5,9 +5,9 @@ require_once __DIR__ . '/functions/autoload_helper.php';
 try {
     require_vendor_autoload(__DIR__);
     require_once __DIR__ . '/functions/env_loader.php';
-    require_once __DIR__ . '/functions/dbconn.php';
+require_once __DIR__ . '/functions/dbconn.php';
 } catch (RuntimeException $e) {
-    echo $e->getMessage();
+    echo '<p>' . htmlspecialchars($e->getMessage()) . '</p>';
     exit(1);
 }
 

--- a/process/operations/main.php
+++ b/process/operations/main.php
@@ -39,6 +39,14 @@ $response = [
     'audioPlayer' => ''
 ];
 
+try {
+    require_once dirname(__DIR__, 2) . '/functions/dbconn.php';
+} catch (RuntimeException $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => $e->getMessage()]);
+    exit;
+}
+
 // Variables de conexión que se usarán en el bloque principal.
 $conn = null;
 $koha = null;
@@ -50,8 +58,6 @@ try {
     }
 
     // --- PASO 2: ESTABLECER Y VERIFICAR CONEXIONES A LA BASE DE DATOS ---
-    require_once dirname(__DIR__, 2) . '/functions/dbconn.php';
-    
     // Conexiones a la BD establecidas en dbconn.php
     if (!isset($conn) || !$conn instanceof mysqli || $conn->connect_error) {
         throw new RuntimeException(


### PR DESCRIPTION
## Summary
- make `handleConnectionError()` always throw an exception
- show a user-friendly message on the login and index pages
- return JSON error response for API when DB connection fails

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a59e463448326b5e36f6a0ff7a467