### PR TITLE
Remove redundant check for Google credentials

### DIFF
--- a/functions/dbconn.php
+++ b/functions/dbconn.php
@@ -13,10 +13,6 @@ foreach ($required as $key) {
     }
 }
 
-if (!isset($_ENV['GOOGLE_APPLICATION_CREDENTIALS']) || trim($_ENV['GOOGLE_APPLICATION_CREDENTIALS']) === '') {
-    throw new RuntimeException('❌ Falta la variable de entorno: GOOGLE_APPLICATION_CREDENTIALS');
-}
-
 // Configuración de logs y depuración
 $debug = isset($_ENV['DEBUG']) && $_ENV['DEBUG'] == 1;
 $logFile = dirname(__DIR__) . '/logs/error.log';


### PR DESCRIPTION
## Summary
- remove duplicated env var check for `GOOGLE_APPLICATION_CREDENTIALS`

## Testing
- `php -l functions/dbconn.php`
- `composer validate`

------
https://chatgpt.com/codex/tasks/task_e_685a59de3c0883268f72a2f1e4b07734