### PR TITLE
Update DB script and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Sigue estos pasos para configurar el proyecto en tu entorno local:
 
 3.  **Configurar la Base de Datos:**
     -   Crea una base de datos MySQL para el proyecto (ej. `inout_db`).
-    -   Importa el esquema de la base de datos y ejecuta las consultas de `updatedb.txt` (incluye la creación de la tabla `inout_log`).
+    -   Importa el esquema de la base de datos y ejecuta las consultas de `updatedb.txt` (incluye la creación de la tabla `inout_log` y el `CREATE TABLE users` con las columnas `lib_name`, `banner` y `dashboard`).
     -   Copia el archivo `.env.example` a `.env` y actualiza las credenciales de conexión. **Este archivo es obligatorio para que la aplicación pueda conectarse a la base de datos:**
         ```bash
         cp .env.example .env

--- a/updatedb.txt
+++ b/updatedb.txt
@@ -37,3 +37,19 @@ CREATE TABLE `inout_log` (
   `status` varchar(10) NOT NULL,
   PRIMARY KEY (`log_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+# Create table for users
+CREATE TABLE `users` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user` varchar(50) NOT NULL,
+  `name` varchar(100) NOT NULL,
+  `pass` varchar(255) NOT NULL,
+  `role` int(11) NOT NULL,
+  `loc` varchar(100) NOT NULL DEFAULT '',
+  `active` tinyint(1) NOT NULL DEFAULT '1',
+  `llogin` varchar(30) DEFAULT NULL,
+  `lib_name` varchar(100) DEFAULT NULL,
+  `banner` varchar(20) DEFAULT 'false',
+  `dashboard` varchar(50) DEFAULT 'quote',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
## Summary
- add full `CREATE TABLE users` definition to `updatedb.txt`
- mention the new statement in database setup instructions

## Testing
- `composer validate --no-check-all --ansi` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ac34f99688326962417ec652dc386