### PR TITLE
Fix login user query

### DIFF
--- a/login_verify.php
+++ b/login_verify.php
@@ -16,8 +16,8 @@ $conn = get_db_connection();
 try {
     $user = sanitize($conn, $_POST['user']);
     $stmt = $conn->prepare(
-        "SELECT id, user, name, pass, role, loc, lib_name, banner, dashboard
-         FROM users WHERE user = ?"
+        "SELECT id, username, fname, pass, role, loc, lib_name, banner, dashboard
+         FROM users WHERE username = ?"
     );
     $stmt->bind_param('s', $user);
     $stmt->execute();
@@ -28,7 +28,7 @@ try {
     if ($udata && password_verify($_POST['pass'], $udata['pass'])) {
         // Éxito: Guardar datos en la sesión y redirigir.
         $_SESSION['id'] = $udata['id'];
-        $_SESSION['user_name'] = $udata['name'];
+        $_SESSION['user_name'] = $udata['fname'];
         $_SESSION['role'] = $udata['role'];
         $_SESSION['loc'] = $udata['loc'];
         $_SESSION['lib_name'] = $udata['lib_name'];


### PR DESCRIPTION
## Summary
- query for login now selects `username` and `fname`
- store `fname` in the session for greeting

## Testing
- `php -l login_verify.php`
- `composer install --no-interaction`

------
https://chatgpt.com/codex/tasks/task_e_685ac91202b8832693ceb8b5a7c37e20