### PR TITLE
Improve session management

### DIFF
--- a/backup.php
+++ b/backup.php
@@ -1,5 +1,5 @@
 <?php
-  session_start();
+  require_once "./functions/session.php";
   // ob_start(ob_gzhandler);
   $title = "Backup";
   $acc_code = "R01";

--- a/blank.php
+++ b/blank.php
@@ -1,5 +1,5 @@
 <?php
-	session_start();
+        require_once "./functions/session.php";
 	// ob_start(ob_gzhandler);
 	$title = "Dashboard";
 	$acc_code = "";

--- a/edit_role.php
+++ b/edit_role.php
@@ -1,5 +1,5 @@
 <?php
-	session_start();
+        require_once "./functions/session.php";
 	// ob_start(ob_gzhandler);
 	$title = "Edit Role";
 	$acc_code = "A02";

--- a/edit_user.php
+++ b/edit_user.php
@@ -1,5 +1,5 @@
 <?php
-	session_start();	
+        require_once "./functions/session.php";
 	// ob_start(ob_gzhandler);
 	$title = "Edit Role";
 	$acc_code = "A02";

--- a/functions/session.php
+++ b/functions/session.php
@@ -1,0 +1,15 @@
+<?php
+$secure = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off');
+if (PHP_VERSION_ID >= 70300) {
+    session_set_cookie_params([
+        'httponly' => true,
+        'secure' => $secure,
+        'samesite' => 'Lax'
+    ]);
+} else {
+    session_set_cookie_params(0, '/', '', $secure, true);
+}
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+?>

--- a/functions/signout.php
+++ b/functions/signout.php
@@ -1,5 +1,5 @@
 <?php
-	session_start();
+        require_once __DIR__ . '/session.php';
 	session_destroy();
 	header("Location:../login.php?msg=2");
 ?>

--- a/index.php
+++ b/index.php
@@ -1,5 +1,5 @@
 <?php
-	session_start();
+        require_once "./functions/session.php";
 	// ob_start(ob_gzhandler);
 	$title = "Dashboard";
 	$acc_code = "INDEX";

--- a/login_verify.php
+++ b/login_verify.php
@@ -1,5 +1,5 @@
 <?php
-	session_start();
+require_once "./functions/session.php";
 	if(!isset($_POST['submit'])){
 		header('location:login.php');
 		exit;
@@ -49,7 +49,8 @@
 			$_SESSION['user_id'] = $user['id'];
 			$_SESSION['user_role'] = $role['rname'];
 			$_SESSION['user_name'] = $user['fname'];
-			$_SESSION['user_access'] = explode(';', $role['acc_code']);
+        $_SESSION['user_access'] = explode(';', $role['acc_code']);
+        session_regenerate_id(true);
 
 			if($loc != "Master"){
         if($role['rname'] == "Admin"){

--- a/notice.php
+++ b/notice.php
@@ -1,5 +1,5 @@
 <?php
-	session_start();
+        require_once "./functions/session.php";
 	// ob_start(ob_gzhandler);
 	$title = "Notice";
 	$acc_code = "N01";

--- a/process/admin/backup.php
+++ b/process/admin/backup.php
@@ -1,5 +1,5 @@
 <?php
-  session_start();
+  require '../../functions/session.php';
   require '../../functions/dbconn.php';
   require '../../functions/dbfunc.php';
   require '../../functions/general.php';

--- a/process/operations/main.php
+++ b/process/operations/main.php
@@ -1,5 +1,5 @@
 <?php
-    session_start();
+    require '../../functions/session.php';
     $loc = $_SESSION['loc'];
     include './functions/dbconn.php';
     include './functions/general.php';

--- a/register.php
+++ b/register.php
@@ -1,5 +1,5 @@
 <?php
-	session_start();
+        require_once "./functions/session.php";
 	// ob_start(ob_gzhandler);
 	$title = "Entry Register";
 	$acc_code = "U03";

--- a/report.php
+++ b/report.php
@@ -1,5 +1,5 @@
 <?php
-	session_start();
+        require_once "./functions/session.php";
 	// ob_start(ob_gzhandler);
 	$title = "Report";
 	$acc_code = "R01";

--- a/reports.php
+++ b/reports.php
@@ -1,5 +1,5 @@
 <?php
-	session_start();
+        require_once "./functions/session.php";
 	// ob_start(ob_gzhandler);
 	$title = "Reports";
 	$acc_code = "";

--- a/setup.php
+++ b/setup.php
@@ -1,5 +1,5 @@
 <?php
-	session_start();
+        require_once "./functions/session.php";
 	// ob_start(ob_gzhandler);
 	$title = "Setup";
 	// $acc_code = "S01";

--- a/today.php
+++ b/today.php
@@ -1,5 +1,5 @@
 <?php
-	session_start();
+        require_once "./functions/session.php";
 	// ob_start(ob_gzhandler);
 	$title = "Today's Entry";
 	$acc_code = "U02";

--- a/user.php
+++ b/user.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+require_once "./functions/session.php";
 // if (!isset($_SESSION['CREATED'])) {
 //     $_SESSION['CREATED'] = time();
 // } else if (time() - $_SESSION['CREATED'] > 7200) {

--- a/user_mgnt.php
+++ b/user_mgnt.php
@@ -1,5 +1,5 @@
 <?php
-	session_start();
+        require_once "./functions/session.php";
 	// ob_start(ob_gzhandler);
 	$title = "User Management";
 	$acc_code = "A02";


### PR DESCRIPTION
## Summary
- add centralized session initialization with secure cookie settings
- regenerate session ID after login
- use new session handling across all pages

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ae64bad6c8326a65a7684d685f220