### PR TITLE
Refactor queries to use prepared statements

### DIFF
--- a/login_verify.php
+++ b/login_verify.php
@@ -29,13 +29,16 @@
 	$pass = sha1($pass);
 
 	// get from db
-	$query = "SELECT * from users where username = '".$name."' and pass = '".$pass."'";
-	$result = mysqli_query($conn, $query);
-	if(!$result){
-		echo "Empty data " . mysqli_error($conn);
-		exit;
-	}
-	$user = mysqli_fetch_assoc($result);
+        $stmt = $conn->prepare("SELECT * from users where username = ? and pass = ?");
+        $stmt->bind_param("ss", $name, $pass);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        if(!$result){
+                echo "Empty data " . mysqli_error($conn);
+                exit;
+        }
+        $user = mysqli_fetch_assoc($result);
+        $stmt->close();
 
 	if($name == $user['username'] && $pass == $user['pass'] ){
 		if($user['active']==1){

--- a/process/admin/usr_process.php
+++ b/process/admin/usr_process.php
@@ -8,30 +8,34 @@
 				$a_code .= $code.";";
 			}
 			$id = getsl($conn, 'id', 'roles');
-			$sql = "INSERT INTO roles (id, rname, rdesc, acc_code) VALUES ('".$id."', '".$_POST['role']."', '".$_POST['r_desc']."', '".$a_code."')";
-			if (mysqli_query($conn, $sql)) {
-				header('location:../../user_mgnt.php?msg=2');
-			} else {
-				$err = mysqli_error($conn);
-				if(strpos($err, 'Duplicate entry') !== false){
-					header('location:../../user_mgnt.php?msg=9');
-				}else{
-			    echo "Error: " . $sql . "<br>" . mysqli_error($conn);
-				}
-			}
+                        $stmt = $conn->prepare("INSERT INTO roles (id, rname, rdesc, acc_code) VALUES (?,?,?,?)");
+                        $stmt->bind_param("isss", $id, $_POST['role'], $_POST['r_desc'], $a_code);
+                        if ($stmt->execute()) {
+                                $stmt->close();
+                                header('location:../../user_mgnt.php?msg=2');
+                        } else {
+                                $err = $stmt->error;
+                                if(strpos($err, 'Duplicate entry') !== false){
+                                        header('location:../../user_mgnt.php?msg=9');
+                                }else{
+                            echo "Error: " . $err;
+                                }
+                        }
 		}else{
 			header('location:../../user_mgnt.php?msg=1');
 		}
 	}
 	
 	if(isset($_GET['delrole'])){
-		$id = $_GET['delrole'];
-		$sql = "DELETE FROM roles WHERE id = '$id'";
-		if (mysqli_query($conn, $sql)) {
-			header('location:../../user_mgnt.php?msg=3');
-		} else {
-		    echo "Error: " . $sql . "<br>" . mysqli_error($conn);
-		}
+                $id = $_GET['delrole'];
+                $stmt = $conn->prepare("DELETE FROM roles WHERE id = ?");
+                $stmt->bind_param("i", $id);
+                if ($stmt->execute()) {
+                        $stmt->close();
+                        header('location:../../user_mgnt.php?msg=3');
+                } else {
+                    echo "Error: " . $stmt->error;
+                }
 	}
 
 	if (isset($_POST['editRole'])) {
@@ -40,57 +44,66 @@
 			foreach($_POST['code'] as $code) {
 				$a_code .= $code.";";
 			}
-			$sql = "UPDATE roles SET rname = '".$_POST['role']."', rdesc = '".$_POST['r_desc']."', acc_code = '".$a_code."' WHERE id = '".$_POST['id']."'";
-			if (mysqli_query($conn, $sql)) {
-				header('location:../../user_mgnt.php?msg=4');
-			} else {
-			    echo "Error: " . $sql . "<br>" . mysqli_error($conn);
-			}
+                        $stmt = $conn->prepare("UPDATE roles SET rname = ?, rdesc = ?, acc_code = ? WHERE id = ?");
+                        $stmt->bind_param("sssi", $_POST['role'], $_POST['r_desc'], $a_code, $_POST['id']);
+                        if ($stmt->execute()) {
+                                $stmt->close();
+                                header('location:../../user_mgnt.php?msg=4');
+                        } else {
+                            echo "Error: " . $stmt->error;
+                        }
 		}else{
 			header('location:../../edit_role.php?msg=1');
 		}
 	}
 
 	if (isset($_POST['addUser'])) {
-		$id = getsl($conn, 'id', 'users');
-		$date = date("d/m/Y H:m A");
-		$pass = mysqli_real_escape_string($conn, $_POST['password']);
-		$pass = sha1($pass);
-		$sql = "INSERT INTO users (id, username, fname, pass, role, active, llogin) VALUES ('".$id."', '".$_POST['username']."', '".$_POST['fname']."', '".$pass."', '".$_POST['role']."', '1', '".$date."')";
-		if (mysqli_query($conn, $sql)) {
-			header('location:../../user_mgnt.php?msg=5');
-		} else {
-		    $err = mysqli_error($conn);
-			if(strpos($err, 'Duplicate entry') !== false){
-				header('location:../../user_mgnt.php?msg=8');
-			}else{
-		    echo "Error: " . $sql . "<br>" . mysqli_error($conn);
-			}
-		}
+                $id = getsl($conn, 'id', 'users');
+                $date = date("d/m/Y H:m A");
+                $pass = mysqli_real_escape_string($conn, $_POST['password']);
+                $pass = sha1($pass);
+                $stmt = $conn->prepare("INSERT INTO users (id, username, fname, pass, role, active, llogin) VALUES (?,?,?,?,?, '1', ?)");
+                $stmt->bind_param("isssss", $id, $_POST['username'], $_POST['fname'], $pass, $_POST['role'], $date);
+                if ($stmt->execute()) {
+                        $stmt->close();
+                        header('location:../../user_mgnt.php?msg=5');
+                } else {
+                    $err = $stmt->error;
+                        if(strpos($err, 'Duplicate entry') !== false){
+                                header('location:../../user_mgnt.php?msg=8');
+                        }else{
+                    echo "Error: " . $err;
+                        }
+                }
 	}
 
 	if (isset($_POST['editUser'])) {
-		if(!$_POST['pass']){
-			$sql = "UPDATE users SET username = '".$_POST['username']."', fname = '".$_POST['fname']."', role = '".$_POST['role']."', active = '".$_POST['active']."' WHERE id = '".$_POST['id']."'";
-		}else{
-			$pass = mysqli_real_escape_string($conn, $_POST['pass']);
-			$pass = sha1($pass);
-			$sql = "UPDATE users SET username = '".$_POST['username']."', fname = '".$_POST['fname']."', pass = '".$pass."', role = '".$_POST['role']."', active = '".$_POST['active']."' WHERE id = '".$_POST['id']."'";
-		}
-		if (mysqli_query($conn, $sql)) {
-			header('location:../../user_mgnt.php?msg=6');
-		} else {
-		    echo "Error: " . $sql . "<br>" . mysqli_error($conn);
-		}	
+                if(!$_POST['pass']){
+                        $stmt = $conn->prepare("UPDATE users SET username = ?, fname = ?, role = ?, active = ? WHERE id = ?");
+                        $stmt->bind_param("sssii", $_POST['username'], $_POST['fname'], $_POST['role'], $_POST['active'], $_POST['id']);
+                }else{
+                        $pass = mysqli_real_escape_string($conn, $_POST['pass']);
+                        $pass = sha1($pass);
+                        $stmt = $conn->prepare("UPDATE users SET username = ?, fname = ?, pass = ?, role = ?, active = ? WHERE id = ?");
+                        $stmt->bind_param("ssssii", $_POST['username'], $_POST['fname'], $pass, $_POST['role'], $_POST['active'], $_POST['id']);
+                }
+                if ($stmt->execute()) {
+                        $stmt->close();
+                        header('location:../../user_mgnt.php?msg=6');
+                } else {
+                    echo "Error: " . $stmt->error;
+                }
 	}
 
-	if(isset($_GET['deluser'])){
-		$id = $_GET['deluser'];
-		$sql = "DELETE FROM users WHERE id = '$id'";
-		if (mysqli_query($conn, $sql)) {
-			header('location:../../user_mgnt.php?msg=7');
-		} else {
-		    echo "Error: " . $sql . "<br>" . mysqli_error($conn);
-		}
-	}
+        if(isset($_GET['deluser'])){
+                $id = $_GET['deluser'];
+                $stmt = $conn->prepare("DELETE FROM users WHERE id = ?");
+                $stmt->bind_param("i", $id);
+                if ($stmt->execute()) {
+                        $stmt->close();
+                        header('location:../../user_mgnt.php?msg=7');
+                } else {
+                    echo "Error: " . $stmt->error;
+                }
+        }
 ?>

--- a/process/operations/main.php
+++ b/process/operations/main.php
@@ -11,59 +11,85 @@
         $time = date('H:i:s');
         error_reporting(E_ALL);
         //patron data fetching
-        $sql = "SELECT CONCAT(title,' ',firstname,' ',surname) AS surname,borrowernumber,sex,categorycode,branchcode,sort1,sort2,mobile,email FROM borrowers WHERE cardnumber='$usn' AND dateexpiry > '$date'";
-        $result = mysqli_query($koha, $sql) or die("Invalid query: 2" . mysqli_error());
-        $data1 = mysqli_fetch_row($result);
+        $stmt = $koha->prepare("SELECT CONCAT(title,' ',firstname,' ',surname) AS surname,borrowernumber,sex,categorycode,branchcode,sort1,sort2,mobile,email FROM borrowers WHERE cardnumber=? AND dateexpiry > ?");
+        $stmt->bind_param("ss", $usn, $date);
+        $stmt->execute();
+        $data1 = $stmt->get_result()->fetch_row();
+        $stmt->close();
         //image fetching
-        $sql = "SELECT imagefile FROM patronimage WHERE borrowernumber = '$data1[1]'";
-        $result = mysqli_query($koha, $sql);
-        $data2 = mysqli_fetch_row($result);
+        $stmt = $koha->prepare("SELECT imagefile FROM patronimage WHERE borrowernumber = ?");
+        $stmt->bind_param("s", $data1[1]);
+        $stmt->execute();
+        $data2 = $stmt->get_result()->fetch_row();
+        $stmt->close();
         //Patron category code fetching
-        $sql = "SELECT description FROM categories WHERE categorycode = '$data1[3]'";
-        $result = mysqli_query($koha, $sql);
-        $data3 = mysqli_fetch_row($result);
+        $stmt = $koha->prepare("SELECT description FROM categories WHERE categorycode = ?");
+        $stmt->bind_param("s", $data1[3]);
+        $stmt->execute();
+        $data3 = $stmt->get_result()->fetch_row();
+        $stmt->close();
         //Branch information fetching
-        $sql = "SELECT branchname FROM branches WHERE branchcode = '$data1[4]'";
-        $result = mysqli_query($koha, $sql);
-        $data4 = mysqli_fetch_row($result);
+        $stmt = $koha->prepare("SELECT branchname FROM branches WHERE branchcode = ?");
+        $stmt->bind_param("s", $data1[4]);
+        $stmt->execute();
+        $data4 = $stmt->get_result()->fetch_row();
+        $stmt->close();
         if ($data1) {
-            $sql = "SELECT *  FROM `inout` WHERE `cardnumber` = '$usn' AND `date` = '$date' AND `status` = 'IN'";
-            $result = mysqli_query($conn, $sql) or die("Invalid query: 3" . mysqli_error());
-            $exit = mysqli_fetch_row($result);
+            $stmt = $conn->prepare("SELECT * FROM `inout` WHERE `cardnumber`=? AND `date`=? AND `status`='IN'");
+            $stmt->bind_param("ss", $usn, $date);
+            $stmt->execute();
+            $exit = $stmt->get_result()->fetch_row();
+            $stmt->close();
             if ($exit) {
-                $chk = "SELECT `usn` FROM tmp2 WHERE `usn`='$usn'";
-                $chk2 = mysqli_query($conn, $chk) or die("Invalid query: 4" . mysqli_error());
-                $chk3 = mysqli_fetch_row($chk2);
+                $stmt = $conn->prepare("SELECT `usn` FROM tmp2 WHERE `usn`=?");
+                $stmt->bind_param("s", $usn);
+                $stmt->execute();
+                $chk3 = $stmt->get_result()->fetch_row();
+                $stmt->close();
                 if (!$chk3) {
-                    $sql = "SELECT *  FROM `inout` WHERE `cardnumber` = '$usn' AND `date` = '$date' AND `status` = 'IN'";
-                    $result = mysqli_query($conn, $sql) or die("Invalid query: 5" . mysqli_error());
-                    $chk4 = mysqli_fetch_array($result);
+                    $stmt = $conn->prepare("SELECT * FROM `inout` WHERE `cardnumber`=? AND `date`=? AND `status`='IN'");
+                    $stmt->bind_param("ss", $usn, $date);
+                    $stmt->execute();
+                    $chk4 = $stmt->get_result()->fetch_array();
+                    $stmt->close();
                     if($chk4['loc'] != $_SESSION['locname']){
-                        $sql = "UPDATE `inout` SET `exit` = '$time', `status` = 'OUT' WHERE `sl` = $exit[0];";
-                        $result = mysqli_query($conn, $sql) or die("Invalid query: 6" . mysqli_error());
+                        $stmt = $conn->prepare("UPDATE `inout` SET `exit` = ?, `status`='OUT' WHERE `sl` = ?");
+                        $stmt->bind_param("si", $time, $exit[0]);
+                        $stmt->execute();
+                        $stmt->close();
                         $sl = getsl($conn, "sl", "inout");
-                        $sql = "INSERT INTO `inout` (`sl`, `cardnumber`, `name`, `gender`, `date`, `entry`, `exit`, `status`,`loc`,`cc`,`branch`,`sort1`,`sort2`,`email`,`mob`) VALUES ('$sl', '$usn', '$data1[0]', '$data1[2]', '$date', '$time', '".$_SESSION['libtime']."', 'IN','$loc','$data3[0]','$data4[0]','$data1[5]','$data1[6]','$data1[8]','$data1[7]');";
-                        $result = mysqli_query($conn, $sql) or die("Invalid query: 7" . mysqli_error());
+                        $stmt = $conn->prepare("INSERT INTO `inout` (`sl`, `cardnumber`, `name`, `gender`, `date`, `entry`, `exit`, `status`,`loc`,`cc`,`branch`,`sort1`,`sort2`,`email`,`mob`) VALUES (?,?,?,?,?, ?, 'IN',?,?,?,?,?,?,?,?)");
+                        $stmt->bind_param("isssssssssssss", $sl, $usn, $data1[0], $data1[2], $date, $time, $_SESSION['libtime'], $loc, $data3[0], $data4[0], $data1[5], $data1[6], $data1[8], $data1[7]);
+                        $stmt->execute();
+                        $stmt->close();
                         $e_name = $data1[0];
                         $d_status = "IN";
                         $msg = "1";
                         $e_img = $data2[0];
                         $time1 = date('g:i A', strtotime($time));
-                        $sql = "INSERT INTO `tmp2` (`usn`, `time`) VALUES ('$usn', CURRENT_TIMESTAMP);";
-                        $result = mysqli_query($conn, $sql) or die("Invalid query: 8" . mysqli_error());
+                        $stmt = $conn->prepare("INSERT INTO `tmp2` (`usn`, `time`) VALUES (?, CURRENT_TIMESTAMP)");
+                        $stmt->bind_param("s", $usn);
+                        $stmt->execute();
+                        $stmt->close();
                     }else{
-                        $sql = "UPDATE `inout` SET `exit` = '$time', `status` = 'OUT' WHERE `sl` = $exit[0];";
-                        $result = mysqli_query($conn, $sql) or die("Invalid query: 9" . mysqli_error());
-                        $sql = "SELECT SUBTIME(`exit`,`entry`)  FROM `inout` WHERE `cardnumber`='$usn' AND `sl` = $exit[0];";
-                        $result = mysqli_query($conn, $sql) or die("Invalid query: 10" . mysqli_error());
-                        $otime = mysqli_fetch_row($result);
+                        $stmt = $conn->prepare("UPDATE `inout` SET `exit` = ?, `status`='OUT' WHERE `sl` = ?");
+                        $stmt->bind_param("si", $time, $exit[0]);
+                        $stmt->execute();
+                        $stmt->close();
+                        $stmt = $conn->prepare("SELECT SUBTIME(`exit`,`entry`) FROM `inout` WHERE `cardnumber`=? AND `sl` = ?");
+                        $stmt->bind_param("si", $usn, $exit[0]);
+                        $stmt->execute();
+                        $otime = $stmt->get_result()->fetch_row();
+                        $stmt->close();
                         $e_name = $data1[0];
                         $d_status = "OUT";
                         $msg = "4";
                         $e_img = $data2[0];
                         $time1 = date('g:i A', strtotime($time));
-                        $sql = "INSERT INTO `tmp2` (`usn`, `time`) VALUES ('$usn', CURRENT_TIMESTAMP);";
-                        $result = mysqli_query($conn, $sql) or die("Invalid query: 8" . mysqli_error());
+                        $stmt = $conn->prepare("INSERT INTO `tmp2` (`usn`, `time`) VALUES (?, CURRENT_TIMESTAMP)");
+                        $stmt->bind_param("s", $usn);
+                        $stmt->execute();
+                        $stmt->close();
                     }
                 } else {
                     $msg = "2";
@@ -74,9 +100,11 @@
                     $time1 = "-";
                 }
             } else {
-              $chk = "SELECT `usn` FROM tmp2 WHERE `usn`='$usn'";
-              $chk2 = mysqli_query($conn, $chk) or die("Invalid query: 4" . mysqli_error());
-              $chk3 = mysqli_fetch_row($chk2);
+              $stmt = $conn->prepare("SELECT `usn` FROM tmp2 WHERE `usn`=?");
+              $stmt->bind_param("s", $usn);
+              $stmt->execute();
+              $chk3 = $stmt->get_result()->fetch_row();
+              $stmt->close();
               if($chk3){
                 $msg = "5";
                 $e_name = NULL;
@@ -86,15 +114,19 @@
                 $time1 = "-";
               } elseif ($data1) {
                     $sl = getsl($conn, "sl", "inout");
-                    $sql = "INSERT INTO `inout` (`sl`, `cardnumber`, `name`, `gender`, `date`, `entry`, `exit`, `status`,`loc`,`cc`,`branch`,`sort1`,`sort2`,`email`,`mob`) VALUES ('$sl', '$usn', '$data1[0]', '$data1[2]', '$date', '$time', '".$_SESSION['libtime']."', 'IN','$loc','$data3[0]','$data4[0]','$data1[5]','$data1[6]','$data1[8]','$data1[7]');";
-                    $result = mysqli_query($conn, $sql) or die("Invalid query: 11" . mysqli_error($conn));
+                    $stmt = $conn->prepare("INSERT INTO `inout` (`sl`, `cardnumber`, `name`, `gender`, `date`, `entry`, `exit`, `status`,`loc`,`cc`,`branch`,`sort1`,`sort2`,`email`,`mob`) VALUES (?,?,?,?,?, ?, 'IN',?,?,?,?,?,?,?,?)");
+                    $stmt->bind_param("isssssssssssss", $sl, $usn, $data1[0], $data1[2], $date, $time, $_SESSION['libtime'], $loc, $data3[0], $data4[0], $data1[5], $data1[6], $data1[8], $data1[7]);
+                    $stmt->execute();
+                    $stmt->close();
                     $e_name = $data1[0];
                     $d_status = "IN";
                     $msg = "1";
                     $e_img = $data2[0];
                     $time1 = date('g:i A', strtotime($time));
-                    $sql = "INSERT INTO `tmp2` (`usn`, `time`) VALUES ('$usn', CURRENT_TIMESTAMP);";
-                    $result = mysqli_query($conn, $sql) or die("Invalid query: 12" . mysqli_error());
+                    $stmt = $conn->prepare("INSERT INTO `tmp2` (`usn`, `time`) VALUES (?, CURRENT_TIMESTAMP)");
+                    $stmt->bind_param("s", $usn);
+                    $stmt->execute();
+                    $stmt->close();
                 }
             }
         } else {


### PR DESCRIPTION
## Summary
- switch login verification query to use parameter binding
- update admin processing scripts to use prepared statements for user and role management
- rewrite operations main flow with bound parameters

## Testing
- `php -l login_verify.php`
- `php -l process/admin/usr_process.php`
- `php -l process/operations/main.php`


------
https://chatgpt.com/codex/tasks/task_e_685ae64a1db88326a70cc1ea1f9890eb