### PR TITLE
Use env vars for DB connection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Example environment configuration
+INOUT_DB_HOST=localhost
+INOUT_DB_USER=your_inout_user
+INOUT_DB_PASS=your_inout_password
+INOUT_DB_NAME=inout_database
+
+KOHA_DB_HOST=localhost
+KOHA_DB_USER=your_koha_user
+KOHA_DB_PASS=your_koha_password
+KOHA_DB_NAME=koha_database

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 blank.php
+.env

--- a/README.md
+++ b/README.md
@@ -91,6 +91,22 @@ https://ticket.playtech.in/
 
 For first time, create a new account. 
 
+## Configuration
+
+Copy `.env.example` to `.env` and update the values with your database credentials before running the application.
+
+Environment variables used:
+
+- `INOUT_DB_HOST`
+- `INOUT_DB_USER`
+- `INOUT_DB_PASS`
+- `INOUT_DB_NAME`
+- `KOHA_DB_HOST`
+- `KOHA_DB_USER`
+- `KOHA_DB_PASS`
+- `KOHA_DB_NAME`
+
+
 
 Introduction:
 

--- a/functions/dbconn.php
+++ b/functions/dbconn.php
@@ -1,29 +1,28 @@
 <?php
-//define('ENV_FILE', '/u01/vhosts/inout.upeu.edu.pe/httpdocs/koha-inout/fronts/koha-inout-lima/.env');
-//require_once ENV_FILE;
+// Database connection settings are read from environment variables.
 
-//	$servername  = getenv('INOUT_DB_HOST');
-	$servername = "consola-mariadb";
-	$username = "Uinoutl";
-	$password = "DbL1n0u72023#$";
-	$db = "inout_bul";
-	$conn = mysqli_connect($servername, $username, $password, $db);
-	if (!$conn) {
-	    die("Connection failed: " . mysqli_connect_error($conn));
-	}
+$servername  = $_ENV['INOUT_DB_HOST'] ?? 'localhost';
+$username    = $_ENV['INOUT_DB_USER'] ?? '';
+$password    = $_ENV['INOUT_DB_PASS'] ?? '';
+$db          = $_ENV['INOUT_DB_NAME'] ?? '';
 
-    	$kohaServername = "consola-mariadb";
-	$kohaUsername = "koha_bul";
-	$kohaPassword = 'rP"K)|k#TjQEHs8w';
-    	$kohaDb = "koha_bul";
-    	$koha = mysqli_connect($kohaServername, $kohaUsername, $kohaPassword, $kohaDb);
-    	if (!$koha) {
-        	die("Connection failed: " . mysqli_connect_error($koha));
-    	}
+$conn = mysqli_connect($servername, $username, $password, $db);
+if (!$conn) {
+    die("Connection failed: " . mysqli_connect_error($conn));
+}
 
-	function sanitize($conn, $str){
-		return mysqli_real_escape_string($conn, $str);
-	}
-	// var_dump(function_exists('mysqli_connect'));
-	date_default_timezone_set("America/Lima");
+$kohaServername = $_ENV['KOHA_DB_HOST'] ?? 'localhost';
+$kohaUsername   = $_ENV['KOHA_DB_USER'] ?? '';
+$kohaPassword   = $_ENV['KOHA_DB_PASS'] ?? '';
+$kohaDb         = $_ENV['KOHA_DB_NAME'] ?? '';
+$koha = mysqli_connect($kohaServername, $kohaUsername, $kohaPassword, $kohaDb);
+if (!$koha) {
+    die("Connection failed: " . mysqli_connect_error($koha));
+}
+
+function sanitize($conn, $str){
+    return mysqli_real_escape_string($conn, $str);
+}
+
+date_default_timezone_set("America/Lima");
 ?>


### PR DESCRIPTION
## Summary
- load DB credentials from environment variables
- add example environment file
- document env vars in README
- ignore local `.env` file

## Testing
- `php -l functions/dbconn.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ae64786b08326b36f4613a89be9fa