### PR TITLE
Add environment loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,13 @@ https://ticket.playtech.in/
 
 For first time, create a new account. 
 
-## Configuration
+## Environment Setup
 
-Copy `.env.example` to `.env` and update the values with your database credentials before running the application.
+Copy `.env.example` to `.env` and fill in your database credentials. The
+application will automatically load these values before establishing database
+connections.
 
-Environment variables used:
+Required variables:
 
 - `INOUT_DB_HOST`
 - `INOUT_DB_USER`

--- a/functions/dbconn.php
+++ b/functions/dbconn.php
@@ -1,4 +1,7 @@
 <?php
+// Ensure environment variables from .env are loaded
+require_once __DIR__ . '/env.php';
+
 // Database connection settings are read from environment variables.
 
 $servername  = $_ENV['INOUT_DB_HOST'] ?? 'localhost';

--- a/functions/env.php
+++ b/functions/env.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Simple .env loader used when vlucas/phpdotenv is not installed.
+ * Reads key=value pairs from the project root .env file and populates
+ * the $_ENV superglobal and environment variables.
+ */
+if (!defined('ENV_LOADED')) {
+    $path = dirname(__DIR__) . '/.env';
+    if (is_readable($path)) {
+        foreach (file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
+            if (strpos(trim($line), '#') === 0) {
+                continue;
+            }
+            if (strpos($line, '=') === false) {
+                continue;
+            }
+            list($name, $value) = array_map('trim', explode('=', $line, 2));
+            if ($name !== '' && !array_key_exists($name, $_ENV)) {
+                $_ENV[$name] = $value;
+                putenv("{$name}={$value}");
+            }
+        }
+    }
+    define('ENV_LOADED', true);
+}
+?>


### PR DESCRIPTION
## Summary
- automatically load `.env` when creating DB connections
- explain env setup in the README

## Testing
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_685b1087a0648326b739b4f43df081c4