### PR TITLE
Fix remaining mysqli_error call

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -208,7 +208,7 @@
 			        <div class="card-body">
 		            <?php 
 		              $query = "SELECT loc FROM `loc`";
-		              $result = mysqli_query($conn, $query) or die("Invalid query: " . mysqli_error());
+                              $result = mysqli_query($conn, $query) or die("Invalid query: " . mysqli_error($conn));
 		              while($res = mysqli_fetch_array($result)){
 		                echo "<div class='row'><div class='col-md-12'><h4>".$res['loc']."</h4></div></div>";
 		              }


### PR DESCRIPTION
## Summary
- use connection handle when printing setup.php query error

## Testing
- `php -l setup.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ae2c91ac48326a4570ef154c6bdaa