### PR TITLE
Switch to generic DB env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
 # Example environment configuration
-INOUT_DB_HOST=localhost
-INOUT_DB_USER=your_inout_user
-INOUT_DB_PASS=your_inout_password
-INOUT_DB_NAME=inout_database
+DB_HOST=localhost
+DB_USER=your_inout_user
+DB_PASS=your_inout_password
+DB_NAME=inout_database
 
 KOHA_DB_HOST=localhost
 KOHA_DB_USER=your_koha_user

--- a/README.md
+++ b/README.md
@@ -99,14 +99,17 @@ connections.
 
 Required variables:
 
-- `INOUT_DB_HOST`
-- `INOUT_DB_USER`
-- `INOUT_DB_PASS`
-- `INOUT_DB_NAME`
+- `DB_HOST`
+- `DB_USER`
+- `DB_PASS`
+- `DB_NAME`
 - `KOHA_DB_HOST`
 - `KOHA_DB_USER`
 - `KOHA_DB_PASS`
 - `KOHA_DB_NAME`
+
+Legacy variable names `INOUT_DB_HOST`, `INOUT_DB_USER`, `INOUT_DB_PASS` and
+`INOUT_DB_NAME` are still honored if the new variables are not present.
 
 
 

--- a/functions/dbconn.php
+++ b/functions/dbconn.php
@@ -4,10 +4,18 @@ require_once __DIR__ . '/env.php';
 
 // Database connection settings are read from environment variables.
 
-$servername  = $_ENV['INOUT_DB_HOST'] ?? 'localhost';
-$username    = $_ENV['INOUT_DB_USER'] ?? '';
-$password    = $_ENV['INOUT_DB_PASS'] ?? '';
-$db          = $_ENV['INOUT_DB_NAME'] ?? '';
+$servername  = $_ENV['DB_HOST']  
+    ?? $_ENV['INOUT_DB_HOST']  
+    ?? 'localhost';
+$username    = $_ENV['DB_USER']  
+    ?? $_ENV['INOUT_DB_USER']  
+    ?? '';
+$password    = $_ENV['DB_PASS']  
+    ?? $_ENV['INOUT_DB_PASS']  
+    ?? '';
+$db          = $_ENV['DB_NAME']  
+    ?? $_ENV['INOUT_DB_NAME']  
+    ?? '';
 
 $conn = mysqli_connect($servername, $username, $password, $db);
 if (!$conn) {


### PR DESCRIPTION
## Summary
- update `.env.example` with DB_* variables
- migrate `functions/dbconn.php` to prefer DB_* vars with fallback
- adjust README to document new variables and legacy support

## Testing
- `php -l functions/dbconn.php` *(fails: command not found)*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685b5796eefc8326b7a9f571535e6956