### PR TITLE
Include session before DB connection on login

### DIFF
--- a/login.php
+++ b/login.php
@@ -1,8 +1,11 @@
+<?php
+require_once './functions/session.php';
+?>
 <!DOCTYPE html>
 <html lang="en" class="perfect-scrollbar-off">
   <head>
     <?php
-      include './functions/dbconn.php';
+      require_once './functions/dbconn.php';
     ?>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">


### PR DESCRIPTION
## Summary
- require the session/bootstrap script before dbconn in `login.php`

## Testing
- `php -l login.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685b57f3fbd88326a138e202c540414b