### PR TITLE
Add flexible MessageHandler

### DIFF
--- a/functions/MessageHandler.php
+++ b/functions/MessageHandler.php
@@ -1,27 +1,54 @@
 <?php
 class MessageHandler {
-    private $templates;
+    private array $templates;
 
     public function __construct() {
         $this->templates = [
-            '1' => "<span class='text-primary'>Your {label} is: {usn}<br>Entry time is: {time}</span>",
-            '2' => "<span class='text-warning'>You just Checked In.<br> Wait for 10 Seconds to Check Out.</span>",
-            '3' => "<span class='text-danger'>Invalid or Expired {label}<br> Contact Librarian for more details.</span>",
-            '4' => "<span class='text-success'>Your Exit time is: {time}<br><span class='text-warning'>Total Time Duration : {duration}</span>",
-            '5' => "<span class='text-info'>You just Checked Out.<br> Wait for 10 Seconds to Check In.</span>"
+            'entry'    => "<span class='text-primary'>Your {label} is: {usn}<br>Entry time is: {time}</span>",
+            'exit'     => "<span class='text-success'>Your Exit time is: {time}<br><span class='text-warning'>Total Time Duration : {duration}</span>",
+            'birthday' => "<span class='text-success'>Happy Birthday {name}!</span>",
+            'expired'  => "<span class='text-danger'>Invalid or Expired {label}<br>Contact Librarian for more details.</span>",
+            'not_found'=> "<span class='text-danger'>User not found</span>"
         ];
     }
 
-    public function getMessage($code, array $data = []) {
-        if (!isset($this->templates[$code])) {
-            return '';
+    public function getMessage(string $eventType, ?array $userData = null): string {
+        $userData = $userData ?? [];
+
+        if (!empty($userData['borrowernotes'])) {
+            return htmlspecialchars($userData['borrowernotes'], ENT_QUOTES, 'UTF-8');
         }
-        $message = $this->templates[$code];
+
+        if (isset($userData['dateofbirth']) && $this->isBirthday($userData['dateofbirth'])) {
+            return $this->replacePlaceholders($this->templates['birthday'], $userData);
+        }
+
+        if (isset($this->templates[$eventType])) {
+            return $this->replacePlaceholders($this->templates[$eventType], $userData);
+        }
+
+        return '';
+    }
+
+    private function replacePlaceholders(string $template, array $data): string {
         foreach ($data as $key => $value) {
-            $message = str_replace('{' . $key . '}', htmlspecialchars($value, ENT_QUOTES, 'UTF-8'), $message);
+            $template = str_replace('{' . $key . '}', htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8'), $template);
         }
-        // Remove any unreplaced placeholders
-        return preg_replace('/{[^}]+}/', '', $message);
+
+        return preg_replace('/{[^}]+}/', '', $template);
+    }
+
+    private function isBirthday(?string $dateOfBirth): bool {
+        if (!$dateOfBirth) {
+            return false;
+        }
+
+        $timestamp = strtotime($dateOfBirth);
+        if ($timestamp === false) {
+            return false;
+        }
+
+        return date('m-d') === date('m-d', $timestamp);
     }
 }
 ?>


### PR DESCRIPTION
## Summary
- refactor `MessageHandler` to use named event templates
- add placeholder replacement helpers
- implement birthday and borrower note logic

## Testing
- `php -l functions/MessageHandler.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c2949c7108326b1ad8364702c4835