### PR TITLE
Add user name to dashboard messages

### DIFF
--- a/dash.php
+++ b/dash.php
@@ -37,6 +37,7 @@ if (isset($data1)) {
     $userData = [
         'firstname'     => $nameParts[1] ?? '',
         'surname'       => $nameParts[2] ?? '',
+        'name'          => trim($nameParts[1] ?? ''),
         'dateofbirth'   => $data1[10] ?? '',
         'dateexpiry'    => $data1[11] ?? '',
         'categorycode'  => $data1[3] ?? '',


### PR DESCRIPTION
## Summary
- collect the user's first name as `name` in `dash.php`
- pass the name along with other user data to `MessageHandler` so placeholders like `{name}` get filled

## Testing
- `php -l dash.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c2f35a5048326b9f75fdcc9b45567