### PR TITLE
Use config/env for db credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,22 +31,24 @@ Para desplegar la aplicación sigue este resumen. Si necesitas un paso a paso m�
 1. **Instalar dependencias básicas**: Apache o Nginx, PHP 8.1 y las extensiones de MySQL.
 2. **Clonar el repositorio** en el directorio deseado del servidor.
 3. **Importar la base de datos** ejecutando `DB/inout.sql` sobre tu instancia de MariaDB/MySQL.
-4. **Configurar la conexión** editando `functions/dbconn.php` con las credenciales de tu servidor:
+4. **Configurar la conexión** creando un archivo `config.php` en la raíz del proyecto (o definiendo variables de entorno) con las credenciales de tu servidor. Un ejemplo de `config.php` es:
 
     ```php
     <?php
-    mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+    return [
+        'inout_servername' => 'IP_DE_TU_SERVIDOR_DB',
+        'inout_username'   => 'Uinoutl',
+        'inout_password'   => 'DbL1n0u72023#$',
+        'inout_db'         => 'inout_bul',
 
-    $inout_servername = "IP_DE_TU_SERVIDOR_DB";
-    $inout_username   = "Uinoutl";
-    $inout_password   = "DbL1n0u72023#$";
-    $inout_db         = "inout_bul";
-
-    $koha_servername  = "IP_DE_TU_SERVIDOR_DB";
-    $koha_username    = "koha_bul";
-    $koha_password    = 'rP"K)|k#TjQEHs8w';
-    $koha_db          = "koha_bul";
+        'koha_servername'  => 'IP_DE_TU_SERVIDOR_DB',
+        'koha_username'    => 'koha_bul',
+        'koha_password'    => 'rP"K)|k#TjQEHs8w',
+        'koha_db'          => 'koha_bul',
+    ];
     ```
+
+    Este archivo no debe subirse al repositorio. También puedes establecer las credenciales mediante variables de entorno (`INOUT_DB_HOST`, `INOUT_DB_USER`, etc.).
 
 5. **Configurar tu servidor web** creando un VirtualHost que apunte al directorio del proyecto y habilitando el módulo `rewrite`.
 

--- a/functions/dbconn.php
+++ b/functions/dbconn.php
@@ -2,20 +2,28 @@
 // Reporta errores de MySQL como excepciones
 mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 
-// --- Credenciales para la base de datos InOut ---
-$inout_servername = "consola-mariadb"; 
-$inout_username   = "Uinoutl";
-$inout_password   = "DbL1n0u72023#$";
-$inout_db         = "inout_bul";
-
-// --- Credenciales para la base de datos Koha ---
-$koha_servername = "consola-mariadb";
-$koha_username   = "koha_bul";
-$koha_password   = 'rP"K)|k#TjQEHs8w';
-$koha_db         = "koha_bul";
-
 // Establecer la zona horaria correcta
 date_default_timezone_set("America/Lima");
+
+// --- Cargar credenciales desde variables de entorno o un archivo externo ---
+$configFile = __DIR__ . '/../config.php';
+$config = [];
+if (file_exists($configFile)) {
+    $loaded = include $configFile;
+    if (is_array($loaded)) {
+        $config = $loaded;
+    }
+}
+
+$inout_servername = getenv('INOUT_DB_HOST') ?: ($config['inout_servername'] ?? 'consola-mariadb');
+$inout_username   = getenv('INOUT_DB_USER') ?: ($config['inout_username'] ?? 'Uinoutl');
+$inout_password   = getenv('INOUT_DB_PASS') ?: ($config['inout_password'] ?? 'DbL1n0u72023#$');
+$inout_db         = getenv('INOUT_DB_NAME') ?: ($config['inout_db'] ?? 'inout_bul');
+
+$koha_servername  = getenv('KOHA_DB_HOST') ?: ($config['koha_servername'] ?? 'consola-mariadb');
+$koha_username    = getenv('KOHA_DB_USER') ?: ($config['koha_username'] ?? 'koha_bul');
+$koha_password    = getenv('KOHA_DB_PASS') ?: ($config['koha_password'] ?? 'rP"K)|k#TjQEHs8w');
+$koha_db          = getenv('KOHA_DB_NAME') ?: ($config['koha_db'] ?? 'koha_bul');
 
 try {
     // Crear la conexión para InOut


### PR DESCRIPTION
## Summary
- read DB credentials from environment variables or optional `config.php`
- document config method in README

## Testing
- `php -l functions/dbconn.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c338d6218832691c8b044425bd227