### PR TITLE
Fix SQL injection risks in process scripts

### DIFF
--- a/process/operations/main.php
+++ b/process/operations/main.php
@@ -6,12 +6,14 @@
     $sql = "DELETE FROM `tmp2` WHERE `time` < DATE_SUB(NOW(),INTERVAL '00:10' MINUTE_SECOND)";
     $result = mysqli_query($conn, $sql) or die("Invalid query: 1" . mysqli_error());
     if (isset($_GET['id'])) {
-        $usn = strtoupper($_GET['id']);
+        $usn_raw = strtoupper($_GET['id']);
+        $usn = sanitize($conn, $usn_raw); // sanitize for local DB
+        $usn_koha = sanitize($koha, $usn_raw); // sanitize for Koha DB
         $date = date('Y-m-d');
         $time = date('H:i:s');
         error_reporting(E_ALL);
         //patron data fetching
-        $sql = "SELECT CONCAT(title,' ',firstname,' ',surname) AS surname,borrowernumber,sex,categorycode,branchcode,sort1,sort2,mobile,email,title,dateofbirth,dateexpiry,borrowernotes FROM borrowers WHERE cardnumber='$usn'";
+        $sql = "SELECT CONCAT(title,' ',firstname,' ',surname) AS surname,borrowernumber,sex,categorycode,branchcode,sort1,sort2,mobile,email,title,dateofbirth,dateexpiry,borrowernotes FROM borrowers WHERE cardnumber='$usn_koha'";
         $result = mysqli_query($koha, $sql) or die("Invalid query: 2" . mysqli_error());
         $data1 = mysqli_fetch_row($result);
 

--- a/process/operations/process.php
+++ b/process/operations/process.php
@@ -3,8 +3,8 @@
 	require '../../functions/general.php';
   $edate = date("20y-m-d");
 
-	if(isset($_POST['updateDash'])){
-    $activedash = $_POST['activedash'];
+        if(isset($_POST['updateDash'])){
+    $activedash = sanitize($conn, $_POST['activedash']);
     $query = "UPDATE `setup` SET `value` = '$activedash' WHERE `setup`.`var` = 'activedash'";
     $result = mysqli_query($conn, $query) or die("Invalid Query:".mysqli_error());
 
@@ -27,11 +27,11 @@
     $query = "UPDATE `setup` SET `value` = '$ccname' WHERE `setup`.`var` = 'cname'";
     $result = mysqli_query($conn, $query) or die("Invalid Query:".mysqli_error());
 
-    $libtime = $_POST['libtime'];
+    $libtime = sanitize($conn, $_POST['libtime']);
     $query = "UPDATE `setup` SET `value` = '$libtime' WHERE `setup`.`var` = 'libtime'";
     $result = mysqli_query($conn, $query) or die("Invalid Query:".mysqli_error());
 
-    $noname = $_POST['noname'];
+    $noname = sanitize($conn, $_POST['noname']);
     $query = "UPDATE `setup` SET `value` = '$noname' WHERE `setup`.`var` = 'noname'";
     $result = mysqli_query($conn, $query) or die("Invalid Query:".mysqli_error());
 
@@ -53,9 +53,9 @@
   }
 
   if(isset($_POST['addnews'])){
-    $nhead = $_POST['nhead'];
-    $nbody = $_POST['nbody'];
-    $nfoot = $_POST['nfoot'];
+    $nhead = sanitize($conn, $_POST['nhead']);
+    $nbody = sanitize($conn, $_POST['nbody']);
+    $nfoot = sanitize($conn, $_POST['nfoot']);
     $loc = sanitize($conn,$_POST['loc']);
 
     $query = "UPDATE `news` SET `status` = 'No' WHERE `status` = 'Yes' AND `loc` = '".$loc."'";
@@ -70,9 +70,9 @@
   }
 
   if(isset($_GET['nid']) && $_GET['status']){
-    $id = $_GET['nid'];
-    $status = $_GET['status'];
-    $loc = $_GET['loc'];
+    $id = intval($_GET['nid']);
+    $status = sanitize($conn, $_GET['status']);
+    $loc = sanitize($conn, $_GET['loc']);
     $active = ($status == "Yes") ? "No" : "Yes";
     $query = "UPDATE `news` SET `status` = 'No' WHERE `status` = 'Yes' AND `loc` = '".$loc."'";
     $result = mysqli_query($conn, $query) or die("Invalid Query:".mysqli_error($conn));


### PR DESCRIPTION
## Summary
- sanitize GET `id` in `process/operations/main.php`
- sanitize POST inputs in `process/operations/process.php`

## Testing
- `php -l process/operations/main.php` *(fails: command not found)*
- `php -l process/operations/process.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c33a565c48326a6ad66c64d8ba303