### PR TITLE
Remove unused Razorpay script

### DIFF
--- a/login.php
+++ b/login.php
@@ -97,9 +97,6 @@ $msg = $_GET['msg'] ?? null;
                         </div>
                     </div>
                 </form>
-                <form>
-                    <script src="https://checkout.razorpay.com/v1/payment-button.js" data-payment_button_id="pl_GffqOJ4TsFX8hN" async></script>
-                </form>
             </div>
         </div>
         


### PR DESCRIPTION
## Summary
- delete Razorpay payment form from `login.php`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d5017c408832692613e5318b4ce22