### PR TITLE
Add screen and TTS message split

### DIFF
--- a/dash.php
+++ b/dash.php
@@ -14,11 +14,9 @@ $messageHandler = new MessageHandler();
 require_once "functions/PersonalizedGreeting.php";
 $tts = new PersonalizedGreeting();
 
-function renderTtsMessage(string $text): string {
+function renderTtsAudio(string $text): string {
     global $tts;
-    $audio = $tts->synthesize($text);
-    // Provide a class to identify the message element
-    return "<span class=\"animated flash tts-text\">$text</span>" . $audio;
+    return $tts->synthesize($text);
 }
 
 function getEventType($msg)
@@ -235,21 +233,24 @@ if (isset($data1)) {
                                                     'current_hour' => (int)date('H')
                                             ];
                                             $eventType = getEventType($msg);
-                                            $displayMessage = $messageHandler->getMessage($eventType, $messageData, $miscData);
+                                            $screenMessage = $messageHandler->getScreenMessage($eventType, $messageData);
+                                            $ttsMessage    = $messageHandler->getTTSMessage($eventType, $messageData, $miscData);
 
                                             if (in_array($eventType, ['recent_entry', 'recent_exit'])) {
                                                 $last = $_SESSION['recent_msg_time'] ?? 0;
                                                 $type = $_SESSION['recent_msg_type'] ?? '';
                                                 if (time() - $last < 10 && $type === $eventType) {
-                                                    $displayMessage = '';
+                                                    $screenMessage = '';
+                                                    $ttsMessage = '';
                                                 } else {
                                                     $_SESSION['recent_msg_time'] = time();
                                                     $_SESSION['recent_msg_type'] = $eventType;
                                                 }
                                             }
 
-                                                if ($displayMessage !== '') {
-                                                    echo renderTtsMessage($displayMessage);
+                                                if ($screenMessage !== '' || $ttsMessage !== '') {
+                                                    echo $screenMessage;
+                                                    echo renderTtsAudio($ttsMessage);
                                                 } else { ?>
 							<div class="idle">
 								<div class="animated pulse infinite"> 

--- a/functions/MessageHandler.php
+++ b/functions/MessageHandler.php
@@ -25,6 +25,20 @@ class MessageHandler {
     ];
 
     /**
+     * Plantillas breves para los mensajes mostrados en pantalla. Estos textos
+     * se enfocan en ser concisos y se utilizarán únicamente para el mensaje
+     * visible, mientras que la versión detallada será reproducida por TTS.
+     */
+    private array $screenTemplates = [
+        'not_found'    => 'Código no reconocido.',
+        'recent_entry' => 'Entrada ya registrada.',
+        'recent_exit'  => 'Salida ya registrada.',
+        'expired'      => 'Membresía expirada.',
+        'entry'        => 'Entrada registrada.',
+        'exit'         => 'Salida registrada.',
+    ];
+
+    /**
      * Punto de entrada principal para generar un mensaje.
      * La prioridad de generación es la siguiente:
      *  1. Cumpleaños.
@@ -34,6 +48,14 @@ class MessageHandler {
      *  5. Mensajes de entrada o salida normales.
      */
     public function getMessage(string $eventType, ?array $userData = null, array $miscData = []): string {
+        return $this->getTTSMessage($eventType, $userData, $miscData);
+    }
+
+    /**
+     * Obtiene el texto completo que será reproducido por el sistema TTS.
+     * La lógica sigue el mismo orden de prioridades que tenía anteriormente.
+     */
+    public function getTTSMessage(string $eventType, ?array $userData = null, array $miscData = []): string {
         $combinedData = array_merge($userData ?? [], $miscData);
 
         if ($eventType === 'not_found') {
@@ -68,6 +90,36 @@ class MessageHandler {
 
         if ($eventType === 'exit') {
             return $this->replacePlaceholders($this->buildExitMessage($userData), $combinedData);
+        }
+
+        return '';
+    }
+
+    /**
+     * Obtiene el mensaje corto que se mostrará en pantalla. Devuelve la cadena
+     * ya envuelta en un elemento span con las clases de animación.
+     */
+    public function getScreenMessage(string $eventType, array $vars = []): string {
+        $combinedData = $vars;
+
+        // Mensajes simples basados en plantillas predefinidas
+        if (isset($this->screenTemplates[$eventType])) {
+            $text = $this->replacePlaceholders($this->screenTemplates[$eventType], $combinedData);
+            return "<span class=\"animated flash tts-text\">$text</span>";
+        }
+
+        // Mensajes especiales que dependen de datos del usuario
+        if ($eventType !== 'not_found' && !empty($vars)) {
+            if ($this->isBirthday($vars['dateofbirth'] ?? null)) {
+                $text = $this->replacePlaceholders('¡Feliz cumpleaños, {nombre}!', $combinedData);
+                return "<span class=\"animated flash tts-text\">$text</span>";
+            }
+
+            if (!empty($vars['borrowernotes'])) {
+                $combinedData['note'] = $vars['borrowernotes'];
+                $text = $this->replacePlaceholders('Nota: {note}', $combinedData);
+                return "<span class=\"animated flash tts-text\">$text</span>";
+            }
         }
 
         return '';


### PR DESCRIPTION
## Summary
- provide short templates for screen-only text
- move previous message building logic to `getTTSMessage`
- show on-screen message separately from synthesized audio

## Testing
- `php` commands were unavailable so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_685dc3a888188326a3bd4366174abffb