### PR TITLE
Add async TTS playback via AJAX

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -16,3 +16,24 @@ showNotification = function(from, align, message, color) {
     }
   });
 }
+
+function attachAudioRedirect() {
+  const audio = document.getElementById('tts-audio');
+  if (audio) {
+    audio.addEventListener('ended', function () {
+      window.location.replace('dash.php');
+    });
+  }
+}
+
+function playTTS(text) {
+  $.ajax({
+    url: 'tts.php',
+    method: 'POST',
+    data: { text: text },
+    success: function (html) {
+      $('body').append(html);
+      attachAudioRedirect();
+    }
+  });
+}

--- a/dash.php
+++ b/dash.php
@@ -11,14 +11,10 @@
         require "functions/dbfunc.php";
 require_once "functions/MessageHandler.php";
 $messageHandler = new MessageHandler();
-require_once "functions/PersonalizedGreeting.php";
-$tts = new PersonalizedGreeting();
-
 function renderTtsMessage(string $text): string {
-    global $tts;
-    $audio = $tts->synthesize($text);
+    $json = json_encode($text);
     // Provide a class to identify the message element
-    return "<span class=\"animated flash tts-text\">$text</span>" . $audio;
+    return "<span class=\"animated flash tts-text\">$text</span><script>playTTS($json);</script>";
 }
 
 function getEventType($msg)
@@ -337,22 +333,20 @@ if (isset($data1)) {
             });
         }
 
-        const audio = document.getElementById('tts-audio');
-        if (audio) {
-            audio.addEventListener('ended', function () {
-                window.location.replace('dash.php');
-            });
-        } else {
-            // Fallback to previous behavior if no audio is present
-            $('span.animated').one('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend', function() {
+        attachAudioRedirect();
+        setTimeout(function () {
+            if (!document.getElementById('tts-audio')) {
+                // Fallback to previous behavior if no audio is present
+                $('span.animated').one('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend', function() {
+                    setTimeout(function(){
+                        window.location.replace('dash.php');
+                    }, 5200);
+                });
                 setTimeout(function(){
-                    window.location.replace('dash.php');
-                }, 5200);
-            });
-            setTimeout(function(){
-                // window.location.replace("dash.php");
-            }, 9800);
-        }
+                    // window.location.replace("dash.php");
+                }, 9800);
+            }
+        }, 1000);
     });
 </script>
 <!-- MAIN CONTENT ENDS -->

--- a/tts.php
+++ b/tts.php
@@ -1,0 +1,11 @@
+<?php
+require_once __DIR__ . '/functions/PersonalizedGreeting.php';
+
+header('Content-Type: text/html; charset=utf-8');
+
+$text = trim($_POST['text'] ?? '');
+if ($text !== '') {
+    $tts = new PersonalizedGreeting();
+    echo $tts->synthesize($text);
+}
+


### PR DESCRIPTION
## Summary
- add `playTTS` and helper to `assets/js/custom.js`
- create `tts.php` endpoint to generate audio
- call `playTTS` in `dash.php` and adjust redirect logic

## Testing
- `node --version`
- `npm --version` *(npm warns about proxy)*
- ❌ `php -v` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_685dc3b96d6083268044b35711d85f37