### PR TITLE
Fix MessageHandler duplicates and update dash

### DIFF
--- a/dash.php
+++ b/dash.php
@@ -252,7 +252,7 @@ if (isset($data1)) {
 
                                                 if ($screenMessage !== '' || $ttsMessage !== '') {
                                                     echo $screenMessage;
-                                                    echo renderTtsAudio($ttsMessage);
+                                                    echo renderTtsMessage($ttsMessage);
                                                 } else { ?>
 							<div class="idle">
 								<div class="animated pulse infinite"> 

--- a/functions/MessageHandler.php
+++ b/functions/MessageHandler.php
@@ -65,20 +65,6 @@ class MessageHandler {
     private array $ttsTemplates = [];
 
     /**
-     * Plantillas breves para los mensajes mostrados en pantalla. Estos textos
-     * se enfocan en ser concisos y se utilizarán únicamente para el mensaje
-     * visible, mientras que la versión detallada será reproducida por TTS.
-     */
-    private array $screenTemplates = [
-        'not_found'    => 'Código no reconocido.',
-        'recent_entry' => 'Entrada ya registrada.',
-        'recent_exit'  => 'Salida ya registrada.',
-        'expired'      => 'Membresía expirada.',
-        'entry'        => 'Entrada registrada.',
-        'exit'         => 'Salida registrada.',
-    ];
-          
-    /**
      * Punto de entrada principal para generar un mensaje.
      * La prioridad de generación es la siguiente:
      *  1. Cumpleaños.
@@ -147,37 +133,6 @@ class MessageHandler {
 
         return '';
     }
-
-    /**
-     * Obtiene el mensaje corto que se mostrará en pantalla. Devuelve la cadena
-     * ya envuelta en un elemento span con las clases de animación.
-     */
-    public function getScreenMessage(string $eventType, array $vars = []): string {
-        $combinedData = $vars;
-
-        // Mensajes simples basados en plantillas predefinidas
-        if (isset($this->screenTemplates[$eventType])) {
-            $text = $this->replacePlaceholders($this->screenTemplates[$eventType], $combinedData);
-            return "<span class=\"animated flash tts-text\">$text</span>";
-        }
-
-        // Mensajes especiales que dependen de datos del usuario
-        if ($eventType !== 'not_found' && !empty($vars)) {
-            if ($this->isBirthday($vars['dateofbirth'] ?? null)) {
-                $text = $this->replacePlaceholders('¡Feliz cumpleaños, {nombre}!', $combinedData);
-                return "<span class=\"animated flash tts-text\">$text</span>";
-            }
-
-            if (!empty($vars['borrowernotes'])) {
-                $combinedData['note'] = $vars['borrowernotes'];
-                $text = $this->replacePlaceholders('Nota: {note}', $combinedData);
-                return "<span class=\"animated flash tts-text\">$text</span>";
-            }
-        }
-
-        return '';
-    }
-
     /**
      * Construye el mensaje de entrada utilizando la franja horaria,
      * la categoría y el género del usuario.


### PR DESCRIPTION
## Summary
- remove duplicate screen template definitions
- consolidate `getScreenMessage` implementation
- use `renderTtsMessage` helper in `dash.php`

## Testing
- `php -l functions/MessageHandler.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dc9d64ae48326bc420a1441b2f992