### PR TITLE
Fix placeholder substitution for expired account messages

### DIFF
--- a/functions/MessageHandler.php
+++ b/functions/MessageHandler.php
@@ -98,7 +98,7 @@ class MessageHandler {
     private function generateMessage(string $eventType, ?array $userData, array $miscData, array $templates): string {
         $combinedData = array_merge($userData ?? [], $miscData);
 
-        if (isset($templates[$eventType]) && !in_array($eventType, ['entry', 'exit'])) {
+        if (in_array($eventType, ['not_found', 'recent_entry', 'recent_exit'])) {
             return $this->fetchTemplate($templates, $eventType);
         }
 


### PR DESCRIPTION
## Summary
- don't skip placeholder replacement for account expiration messages

## Testing
- `php -l functions/MessageHandler.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dcc042e9c8326a8aa6d98655d1bc6