### PR TITLE
Add text display for TTS message

### DIFF
--- a/dash.php
+++ b/dash.php
@@ -219,9 +219,10 @@ error_reporting(E_ALL);
 
 				<!-- AUDIO SOLO POR TTS, SEGÚN GÉNERO -->
 				<?php
-				if ($ttsMessage !== '') {
-					echo $tts->synthesizeVoice($ttsMessage, $userData['gender'] ?? 'M');
-				}
+                                if ($ttsMessage !== '') {
+                                        echo $tts->synthesizeVoice($ttsMessage, $userData['gender'] ?? 'M');
+                                        echo "<div id=\"tts-text\">" . htmlspecialchars($ttsMessage) . "</div>";
+                                }
 				?>
 
 				<?php if (empty($userData) && $eventType != 'not_found') { ?>


### PR DESCRIPTION
## Summary
- display the spoken message text in dash.php next to the synthesized audio

## Testing
- `php -l dash.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685eba95e3988326a2b2d12ae053e918