### PR TITLE
Add UPeU theme and update dashboard

### DIFF
--- a/assets/css/upeu-theme.css
+++ b/assets/css/upeu-theme.css
@@ -1,0 +1,49 @@
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Roboto:wght@400;700&display=swap');
+
+:root {
+    --upeu-primary: #003e6b;
+    --upeu-accent: #ffb71b;
+}
+
+body {
+    font-family: 'Roboto', sans-serif;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: 'Montserrat', sans-serif;
+}
+
+.upeu-card {
+    border: 1px solid var(--upeu-primary);
+    border-radius: 0.5rem;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.upeu-card-header {
+    background-color: var(--upeu-primary);
+    color: #fff;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid rgba(0,0,0,0.125);
+    border-top-left-radius: 0.5rem;
+    border-top-right-radius: 0.5rem;
+}
+
+.upeu-card-body {
+    padding: 1rem;
+}
+
+.upeu-bg-primary {
+    background-color: var(--upeu-primary) !important;
+}
+
+.upeu-bg-accent {
+    background-color: var(--upeu-accent) !important;
+}
+
+.upeu-text-primary {
+    color: var(--upeu-primary) !important;
+}
+
+.upeu-text-accent {
+    color: var(--upeu-accent) !important;
+}

--- a/dash.php
+++ b/dash.php
@@ -99,8 +99,8 @@ error_reporting(E_ALL);
 	<div class="container-fluid">
 		<div class="row">
 			<div class="col-md-6">
-				<div class="card" style="min-height: calc(100vh - 150px);">
-					<div class="card-body">
+				<div class="card upeu-card" style="min-height: calc(100vh - 150px);">
+					<div class="card-body upeu-card-body">
 						<?php if ($banner): ?>
 							<img class="img-responsive" src="assets/img/banner.png">
 						<?php else: ?>
@@ -148,7 +148,7 @@ error_reporting(E_ALL);
 						<?php endif; ?>
 
 						<?php if ($clock): ?>
-							<div class="card-body">
+							<div class="card-body upeu-card-body">
 								<div class="analogclock">
 									<div>
 										<div class="cinfo cdate"></div>
@@ -189,7 +189,7 @@ error_reporting(E_ALL);
 				<?php
 				// SIEMPRE muestra los datos si hay usuario, incluso si expiró
 				if (!empty($userData)) { ?>
-					<div class="card-body text-center">
+					<div class="card-body upeu-card-body text-center">
 						<?php if ($img_flag): ?>
 							<img src="data:image/jpg/png/jpeg;base64,<?= base64_encode($e_img); ?>" class="rounded-circle mb-4" alt="...">
 						<?php else: ?>
@@ -232,7 +232,7 @@ error_reporting(E_ALL);
 						</div>
 						<div class="row">
 							<div class="col-md-3">
-								<div class="card card-stats">
+								<div class="card upeu-card card-stats">
 									<div class="card-header card-header-info card-header-icon">
 										<div class="card-icon"></div>
 										<p class="card-category">Gentlemen</p>
@@ -246,7 +246,7 @@ error_reporting(E_ALL);
 								</div>
 							</div>
 							<div class="col-md-3">
-								<div class="card card-stats">
+								<div class="card upeu-card card-stats">
 									<div class="card-header card-header-rose card-header-icon">
 										<div class="card-icon"></div>
 										<p class="card-category">Ladies</p>
@@ -260,7 +260,7 @@ error_reporting(E_ALL);
 								</div>
 							</div>
 							<div class="col-md-3">
-								<div class="card card-stats">
+								<div class="card upeu-card card-stats">
 									<div class="card-header card-header-success card-header-icon">
 										<div class="card-icon"></div>
 										<p class="card-category">Checked In</p>
@@ -274,7 +274,7 @@ error_reporting(E_ALL);
 								</div>
 							</div>
 							<div class="col-md-3">
-								<div class="card card-stats">
+								<div class="card upeu-card card-stats">
 									<div class="card-header card-header-warning card-header-icon">
 										<div class="card-icon"></div>
 										<p class="card-category">Day Count</p>

--- a/index.php
+++ b/index.php
@@ -8,7 +8,7 @@
 	require_once "./template/sidebar.php";
 ?>
 <!-- MAIN CONTENT START -->
-<div class="content" style="min-height: calc(100vh - 160px);">
+<div class="content upeu-container" style="min-height: calc(100vh - 160px);">
 	<div class="container-fluid">
 	  <div class="row">
 	    <div class="col-md-12">

--- a/template/header.php
+++ b/template/header.php
@@ -15,6 +15,7 @@
     <link rel="stylesheet" type="text/css" href="assets/css/font-awesome.min.css">
     <link rel="stylesheet" type="text/css" href="assets/css/clock.css">
     <link rel="stylesheet" type="text/css" href="assets/css/animate.css">
+    <link rel="stylesheet" type="text/css" href="assets/css/upeu-theme.css">
     
     <!-- JavaScript -->
     <script src="assets/js/core/jquery.min.js" type="text/javascript"></script>

--- a/today.php
+++ b/today.php
@@ -13,18 +13,18 @@
 	require "functions/general.php";	
 ?>
 <!-- MAIN CONTENT START -->
-<div class="content" style="min-height: calc(100vh - 160px);">
+<div class="content upeu-container" style="min-height: calc(100vh - 160px);">
 	<div class="container-fluid">
 	  <div class="row">
 	    <div class="col-md-12">
-	    	<div class="card">
+	    	<div class="card upeu-card">
 				  <div class="card-header card-header-info card-header-icon">
 				    <div class="card-icon">
 				      <i class="material-icons">assignment</i>
 				    </div>
 				    <h4 class="card-title">Today's In Out Report</h4>
 				  </div>
-				  <div class="card-body">
+				  <div class="card-body upeu-card-body">
 				  	<table id="datatables" class="table table-striped table-no-bordered table-hover" cellspacing="0" width="100%" style="width:100%">
 			        <thead>
 			          <tr>


### PR DESCRIPTION
## Summary
- add UPeU theme stylesheet with Montserrat/Roboto fonts and color variables
- include the stylesheet in the default header
- update dash and dashboard views to use new `upeu-` classes

## Testing
- `php -l template/header.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862baaaaa108326b895b2ea898863b5