### PR TITLE
Dynamic display of Koha new arrivals

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,14 @@ Esta versión (`v1.3.1`) mejora los estilos CSS para una apariencia más pulida.
 * Sistema de roles de usuario (Master, Admin, User).
 * Generación de reportes de actividad.
 * Noticias y anuncios para los usuarios.
+* Novedades bibliográficas con imágenes de portada recientes.
 * Mensajes de saludo dinámicos y personalizados según rol y género.
 * Avisos automáticos cuando la cuenta de un usuario está expirada.
 * Síntesis de voz con Google Cloud Text-to-Speech para mensajes audibles.
 * Configuración flexible mediante variables de entorno.
 * Consultas preparadas y sanitización de entradas para mayor seguridad.
 * El campo de escaneo mantiene el foco automáticamente en el dashboard.
+* El panel de "New Arrivals" consulta Koha para mostrar las portadas de los últimos títulos ingresados.
 
 ## Pila Tecnológica
 

--- a/dash.php
+++ b/dash.php
@@ -121,17 +121,26 @@ error_reporting(E_ALL);
 							</div>
 						<?php endif; ?>
 
-						<?php if ($new_arrivals): ?>
-							<h3 class="text-center">New Arrivals</h3>
-							<div class="new-arrivals">
-								<img src="assets/books/1.png"><img src="assets/books/2.png">
-								<img src="assets/books/3.png"><img src="assets/books/4.png">
-							</div>
-							<div class="new-arrivals">
-								<img src="assets/books/5.png"><img src="assets/books/6.png">
-								<img src="assets/books/7.png"><img src="assets/books/8.png">
-							</div>
-						<?php endif; ?>
+                                                <?php if ($new_arrivals): ?>
+                                                        <h3 class="text-center">New Arrivals</h3>
+                                                        <?php
+                                                        $covers = [];
+                                                        $sql = "SELECT DISTINCT biblionumber FROM items ORDER BY dateaccessioned DESC LIMIT 8";
+                                                        if ($result = mysqli_query($koha, $sql)) {
+                                                                while ($row = mysqli_fetch_assoc($result)) {
+                                                                        $covers[] = '/cgi-bin/koha/opac-image.pl?thumbnail=1&biblionumber=' . urlencode($row['biblionumber']);
+                                                                }
+                                                        }
+                                                        $chunks = array_chunk($covers, 4);
+                                                        foreach ($chunks as $chunk) {
+                                                                echo '<div class="new-arrivals">';
+                                                                foreach ($chunk as $url) {
+                                                                        echo '<img src="' . htmlspecialchars($url) . '" alt="Book cover">';
+                                                                }
+                                                                echo '</div>';
+                                                        }
+                                                        ?>
+                                                <?php endif; ?>
 
 						<?php if ($quote): ?>
 							<div class="card-block2" style="min-height: calc(100vh - 430px);">


### PR DESCRIPTION
## Summary
- query Koha for recent titles in `dash.php`
- output cover images dynamically inside the New Arrivals section
- document new behaviour in README

## Testing
- `php -l dash.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6863e3a8d2e08326a126f5fbe9dc369e