### PR TITLE
Fix new arrivals cover URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ KOHA_DB_USER=koha_bul
 KOHA_DB_PASS="rP\"K)|k#TjQEHs8w"
 KOHA_DB_NAME=koha_bul
 
+# Base URL to your Koha OPAC (used for book cover images)
+KOHA_OPAC_URL=http://localhost
+
 # Path to the Google Cloud Text-to-Speech service account JSON
 TTS_CREDENTIALS_PATH=/path/to/tts_credentials.json
 TTS_LANGUAGE_CODE=es-ES

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Para desplegar la aplicación sigue este resumen. Si necesitas un paso a paso m�
 3. **Importar la base de datos** ejecutando `DB/inout.sql` sobre tu instancia de MariaDB/MySQL.
 4. **Configurar la conexión** copiando el archivo `.env.example` a `.env` y completando tus credenciales de base de datos.
    Si deseas utilizar la síntesis de voz, proporciona también la ruta del JSON de Google en `TTS_CREDENTIALS_PATH`.
+   Para mostrar las carátulas en "New Arrivals" especifica la dirección base de tu OPAC en `KOHA_OPAC_URL`.
 
 5. **Configurar tu servidor web** creando un VirtualHost que apunte al directorio del proyecto y habilitando el módulo `rewrite`.
 

--- a/dash.php
+++ b/dash.php
@@ -125,10 +125,11 @@ error_reporting(E_ALL);
                                                         <h3 class="text-center">New Arrivals</h3>
                                                         <?php
                                                         $covers = [];
+                                                        $baseUrl = rtrim(getenv('KOHA_OPAC_URL') ?: '', '/');
                                                         $sql = "SELECT DISTINCT biblionumber FROM items ORDER BY dateaccessioned DESC LIMIT 8";
                                                         if ($result = mysqli_query($koha, $sql)) {
                                                                 while ($row = mysqli_fetch_assoc($result)) {
-                                                                        $covers[] = '/cgi-bin/koha/opac-image.pl?thumbnail=1&biblionumber=' . urlencode($row['biblionumber']);
+                                                                        $covers[] = $baseUrl . '/cgi-bin/koha/opac-image.pl?thumbnail=1&biblionumber=' . urlencode($row['biblionumber']);
                                                                 }
                                                         }
                                                         $chunks = array_chunk($covers, 4);

--- a/install.md
+++ b/install.md
@@ -172,7 +172,8 @@ nano .env
 ```
 
 Fill in the values for `INOUT_DB_*` y `KOHA_DB_*`. La aplicación leerá
-automáticamente estas variables al iniciar.
+automáticamente estas variables al iniciar. Para que las portadas se muestren,
+define también `KOHA_OPAC_URL` con la URL base de tu OPAC.
 
 ### Step 5: Restart Apache
 


### PR DESCRIPTION
## Summary
- load OPAC base URL from `.env`
- document `KOHA_OPAC_URL`
- mention the new variable in install guide
- update New Arrivals widget to use the configured OPAC URL

## Testing
- `php` lint *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e8c04ee48326aaa7450761dc2d1b