### PR TITLE
Display Koha covers on New Arrivals

### DIFF
--- a/dash.php
+++ b/dash.php
@@ -124,14 +124,8 @@ error_reporting(E_ALL);
                                                 <?php if ($new_arrivals): ?>
                                                         <h3 class="text-center">New Arrivals</h3>
                                                         <?php
-                                                        $covers = [];
-                                                        $baseUrl = rtrim(getenv('KOHA_OPAC_URL') ?: '', '/');
-                                                        $sql = "SELECT DISTINCT biblionumber FROM items ORDER BY dateaccessioned DESC LIMIT 8";
-                                                        if ($result = mysqli_query($koha, $sql)) {
-                                                                while ($row = mysqli_fetch_assoc($result)) {
-                                                                        $covers[] = $baseUrl . '/cgi-bin/koha/opac-image.pl?thumbnail=1&biblionumber=' . urlencode($row['biblionumber']);
-                                                                }
-                                                        }
+                                                        $baseUrl = getenv('KOHA_OPAC_URL') ?: '';
+                                                        $covers = getNewArrivalsCovers($koha, $baseUrl, 8);
                                                         $chunks = array_chunk($covers, 4);
                                                         foreach ($chunks as $chunk) {
                                                                 echo '<div class="new-arrivals">';

--- a/functions/dbfunc.php
+++ b/functions/dbfunc.php
@@ -161,5 +161,25 @@
     return $result;
   }
 
+  /**
+   * Fetch an array of cover image URLs for the most recent items in Koha.
+   *
+   * @param mysqli  $koha    Connection to the Koha database.
+   * @param string  $baseUrl Base OPAC URL. Trailing slash will be trimmed.
+   * @param int     $limit   Number of covers to return.
+   * @return array
+   */
+  function getNewArrivalsCovers(mysqli $koha, string $baseUrl, int $limit = 8): array {
+    $covers = [];
+    $limit = max(1, (int)$limit);
+    $sql = "SELECT DISTINCT biblionumber FROM items ORDER BY dateaccessioned DESC LIMIT $limit";
+    if ($result = mysqli_query($koha, $sql)) {
+      while ($row = mysqli_fetch_assoc($result)) {
+        $covers[] = rtrim($baseUrl, '/') . '/cgi-bin/koha/opac-image.pl?thumbnail=1&biblionumber=' . urlencode($row['biblionumber']);
+      }
+    }
+    return $covers;
+  }
+
 
 ?>


### PR DESCRIPTION
## Summary
- add helper to build Koha cover URLs
- use helper in `dash.php` to show last 8 covers

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863f7223fb08326906279100bbfdc44