### PR TITLE
Update docs for TTS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ Para desplegar la aplicación sigue este resumen. Si necesitas un paso a paso m�
    Asegúrate de que el archivo `.env` esté ubicado en la raíz del proyecto y que
    dicha variable tenga un valor válido; si está vacía no se cargará la URL.
 
+   Para usar Azure Text-to-Speech define además `SPEECH_KEY` y `SPEECH_REGION`
+   en ese mismo archivo. Luego crea (o actualiza) la fila `tts_provider` en la
+   tabla `setup` de la base de datos con el valor `azure` o `google` según el
+   servicio que prefieras.
+
 5. **Configurar tu servidor web** creando un VirtualHost que apunte al directorio del proyecto y habilitando el módulo `rewrite`.
 
 Tras estos pasos la aplicación quedará lista para acceder desde `http://tu-dominio/login.php`.

--- a/install.md
+++ b/install.md
@@ -175,6 +175,10 @@ Fill in the values for `INOUT_DB_*` y `KOHA_DB_*`. La aplicación leerá
 automáticamente estas variables al iniciar. Para que las portadas se muestren,
 define también `KOHA_OPAC_URL` con la URL base de tu OPAC.
 
+If you plan to use text-to-speech you can choose **Google** or **Azure** as the
+provider. Set `SPEECH_KEY` and `SPEECH_REGION` in `.env` for Azure and update the
+`tts_provider` record in the `setup` table (`google` is the default).
+
 ### Step 5: Restart Apache
 
 ```bash
@@ -207,6 +211,9 @@ Now that the system is set up, here's how you can log in:
 
 - **Username:** admin
 - **Password:** library
+
+If you configured a text-to-speech provider, greeting messages will play aloud
+when users log in or out.
 
 ---
 


### PR DESCRIPTION
## Summary
- add instructions for selecting Azure or Google speech provider in README
- document SPEECH_KEY, SPEECH_REGION and tts_provider in install guide
- mention voice notifications in install how-to section

## Testing
- `composer validate --no-check-all` *(fails: command not found)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68682d47da148326aa53c03346199dda