### PR TITLE
Add Microsoft speech SDK dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "minimum-stability": "stable",
     "require": {
         "google/cloud-text-to-speech": "^2.2",
-        "vlucas/phpdotenv": "^5.6"
+        "vlucas/phpdotenv": "^5.6",
+        "microsoft/cognitive-services-speech-sdk-php": "^1.20"
     }
 }


### PR DESCRIPTION
## Summary
- include `microsoft/cognitive-services-speech-sdk-php` in composer.json

## Testing
- `composer update` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68682d439a688326becb5c50c3528301