### PR TITLE
Add Azure TTS option via environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,9 +14,18 @@ KOHA_DB_NAME=koha_bul
 # Don't leave this empty or the covers will not display
 KOHA_OPAC_URL=http://localhost
 
-# Path to the Google Cloud Text-to-Speech service account JSON
-TTS_CREDENTIALS_PATH=/path/to/tts_credentials.json
-TTS_LANGUAGE_CODE=es-ES
-TTS_VOICE_A=es-US-Standard-A
-TTS_VOICE_B=es-US-Standard-C
+# Text-to-Speech provider: google or azure
+TTS_PROVIDER=google
+
+# Google Cloud Text-to-Speech
+GOOGLE_TTS_CREDENTIALS_PATH=/path/to/tts_credentials.json
+GOOGLE_TTS_LANGUAGE_CODE=es-ES
+GOOGLE_TTS_VOICE_A=es-US-Standard-A
+GOOGLE_TTS_VOICE_B=es-US-Standard-C
+
+# Azure Cognitive Services Speech
+SPEECH_KEY=
+SPEECH_REGION=
+AZURE_TTS_VOICE_A=en-US-AndrewNeural
+AZURE_TTS_VOICE_B=en-US-JennyNeural
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ Para desplegar la aplicación sigue este resumen. Si necesitas un paso a paso m�
 2. **Clonar el repositorio** en el directorio deseado del servidor.
 3. **Importar la base de datos** ejecutando `DB/inout.sql` sobre tu instancia de MariaDB/MySQL.
 4. **Configurar la conexión** copiando el archivo `.env.example` a `.env` y completando tus credenciales de base de datos.
-   Si deseas utilizar la síntesis de voz, proporciona también la ruta del JSON de Google en `TTS_CREDENTIALS_PATH`.
+   Si deseas utilizar la síntesis de voz, define el proveedor en `TTS_PROVIDER` (`google` o `azure`).
+   Para Google especifica la ruta del JSON de credenciales en `GOOGLE_TTS_CREDENTIALS_PATH`.
+   Para Azure configura `SPEECH_KEY` y `SPEECH_REGION`.
    Para mostrar las carátulas en "New Arrivals" especifica la dirección base de tu OPAC en `KOHA_OPAC_URL`.
    Asegúrate de que el archivo `.env` esté ubicado en la raíz del proyecto y que
    dicha variable tenga un valor válido; si está vacía no se cargará la URL.

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "minimum-stability": "stable",
     "require": {
         "google/cloud-text-to-speech": "^2.2",
+        "microsoft/cognitive-services-speech-sdk-php": "^1.33",
         "vlucas/phpdotenv": "^5.6"
     }
 }

--- a/functions/AzureSpeech.php
+++ b/functions/AzureSpeech.php
@@ -1,0 +1,58 @@
+<?php
+use Microsoft\CognitiveServices\Speech\SpeechConfig;
+use Microsoft\CognitiveServices\Speech\SpeechSynthesizer;
+use Microsoft\CognitiveServices\Speech\ResultReason;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/env_loader.php';
+
+class AzureSpeech
+{
+    private ?SpeechSynthesizer $synthesizer = null;
+
+    public function __construct()
+    {
+        $key = getenv('SPEECH_KEY');
+        $region = getenv('SPEECH_REGION');
+        if ($key && $region) {
+            try {
+                $speechConfig = SpeechConfig::fromSubscription($key, $region);
+                $this->synthesizer = new SpeechSynthesizer($speechConfig);
+            } catch (\Exception $e) {
+                $this->synthesizer = null;
+            }
+        }
+    }
+
+    public function synthesizeVoice(string $voiceText, string $gender = 'M'): string
+    {
+        if ($this->synthesizer === null || trim($voiceText) === '') {
+            return '';
+        }
+
+        $gender = strtoupper($gender);
+        if ($gender === 'F') {
+            $voiceName = getenv('AZURE_TTS_VOICE_B') ?: 'en-US-JennyNeural';
+        } else {
+            $voiceName = getenv('AZURE_TTS_VOICE_A') ?: 'en-US-AndrewNeural';
+        }
+
+        try {
+            $config = $this->synthesizer->getConfig();
+            $config->setSpeechSynthesisVoiceName($voiceName);
+            $result = $this->synthesizer->speakText($voiceText);
+            if ($result->getReason() !== ResultReason::SynthesizingAudioCompleted) {
+                return '';
+            }
+            $audioData = $result->getAudioData();
+            if (!$audioData) {
+                return '';
+            }
+            $b64 = base64_encode($audioData);
+            $src = "data:audio/mpeg;base64,$b64";
+            return "<audio id=\"tts-audio\" autoplay style=\"display:none\"><source src=\"$src\" type=\"audio/mpeg\"></audio>";
+        } catch (\Exception $e) {
+            return '';
+        }
+    }
+}

--- a/functions/PersonalizedGreeting.php
+++ b/functions/PersonalizedGreeting.php
@@ -15,7 +15,7 @@ class PersonalizedGreeting
 
     public function __construct()
     {
-        $credentials = getenv('TTS_CREDENTIALS_PATH');
+        $credentials = getenv('GOOGLE_TTS_CREDENTIALS_PATH');
         if ($credentials && file_exists($credentials)) {
             putenv('GOOGLE_APPLICATION_CREDENTIALS=' . $credentials);
             try {
@@ -43,14 +43,14 @@ class PersonalizedGreeting
         try {
             $input = new SynthesisInput(['text' => $voiceText]);
 
-            $languageCode = getenv('TTS_LANGUAGE_CODE') ?: 'es-ES';
+            $languageCode = getenv('GOOGLE_TTS_LANGUAGE_CODE') ?: 'es-ES';
 
             // Voz según género:
             $gender = strtoupper($gender);
             if ($gender === 'F') {
-                $voiceName = getenv('TTS_VOICE_B') ?: getenv('TTS_VOICE') ?: 'es-ES-Wavenet-B';
+                $voiceName = getenv('GOOGLE_TTS_VOICE_B') ?: getenv('GOOGLE_TTS_VOICE') ?: 'es-ES-Wavenet-B';
             } else {
-                $voiceName = getenv('TTS_VOICE_A') ?: getenv('TTS_VOICE') ?: 'es-ES-Wavenet-A';
+                $voiceName = getenv('GOOGLE_TTS_VOICE_A') ?: getenv('GOOGLE_TTS_VOICE') ?: 'es-ES-Wavenet-A';
             }
 
             $voice = new VoiceSelectionParams([

--- a/tts.php
+++ b/tts.php
@@ -1,11 +1,19 @@
 <?php
-require_once __DIR__ . '/functions/PersonalizedGreeting.php';
+require_once __DIR__ . '/functions/env_loader.php';
+
+$provider = strtolower(getenv('TTS_PROVIDER') ?: 'google');
+if ($provider === 'azure') {
+    require_once __DIR__ . '/functions/AzureSpeech.php';
+    $tts = new AzureSpeech();
+} else {
+    require_once __DIR__ . '/functions/PersonalizedGreeting.php';
+    $tts = new PersonalizedGreeting();
+}
 
 header('Content-Type: text/html; charset=utf-8');
 
 $text = trim($_POST['text'] ?? '');
 if ($text !== '') {
-    $tts = new PersonalizedGreeting();
     echo $tts->synthesizeVoice($text);
 }
 


### PR DESCRIPTION
## Summary
- add `TTS_PROVIDER` and Azure keys to `.env.example`
- document provider selection in `README.md`
- require Microsoft speech SDK
- update Google TTS helper to use new variable names
- add Azure speech helper and switch logic in `tts.php`

## Testing
- `composer validate --no-check-all --strict` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868fe7646cc83268443dda3053498fb