### PR TITLE
Fix Azure speech autoload path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "minimum-stability": "stable",
     "require": {
         "google/cloud-text-to-speech": "^2.2",
-        "microsoft/cognitive-services-speech-sdk-php": "^1.33",
+        "microsoft/cognitive-services-speech-sdk": "^1.33",
         "vlucas/phpdotenv": "^5.6"
     }
 }

--- a/functions/AzureSpeech.php
+++ b/functions/AzureSpeech.php
@@ -1,10 +1,10 @@
 <?php
+require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/env_loader.php';
+
 use Microsoft\CognitiveServices\Speech\SpeechConfig;
 use Microsoft\CognitiveServices\Speech\SpeechSynthesizer;
 use Microsoft\CognitiveServices\Speech\ResultReason;
-
-require_once __DIR__ . '/../vendor/autoload.php';
-require_once __DIR__ . '/env_loader.php';
 
 class AzureSpeech
 {


### PR DESCRIPTION
## Summary
- replace deprecated `microsoft/cognitive-services-speech-sdk-php` dependency with the official package
- load Composer autoloader before using SDK classes in `AzureSpeech.php`

## Testing
- `composer require microsoft/cognitive-services-speech-sdk` *(fails: composer not found)*
- `composer install` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869eb8e695483269c57bfb0e6819592